### PR TITLE
feat: Add dots background pattern to app shell and login

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,8 @@
     .shell {
       min-height: 100vh;
       background-color: var(--color-canvas-softer);
+      background-image: radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.12) 1px, transparent 0);
+      background-size: 24px 24px;
       color: var(--color-ink);
       font-family: var(--font-text);
     }

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -19,6 +19,8 @@
       display: flex;
       flex-direction: column;
       background-color: var(--color-canvas);
+      background-image: radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.1) 1px, transparent 0);
+      background-size: 24px 24px;
     }
 
     .login-page__nav {


### PR DESCRIPTION
## Summary
- Adds a subtle radial-gradient dot pattern (1px dots on a 24px grid) to the two top-level page wrappers — `.shell` in `templates/base.html` (authenticated app) and `.login-page` in `templates/registration/login.html` (login).
- Pattern uses `rgba(0,0,0,0.12)` over the `#f3f3f3` canvas in the app shell, and `rgba(0,0,0,0.10)` over the white login surface — slightly softer on pure white so it doesn't read harsh.
- Pure CSS, no new assets. Matches the Uber-inspired minimalist black-and-white system described in `DESIGN.md`.

## Why
Gives the canvas a quiet texture so the white cards have something to sit on top of, without introducing any new color or decoration. The fixed sidebar covers the pattern in its column, and content cards keep their solid white surfaces, so the dots only breathe in the canvas/gutter areas.

## Tuning knobs (for follow-up if needed)
- Opacity: currently `0.10`–`0.12`. Lower for fainter, higher for stronger.
- Grid size: currently `24px`. Try `28px`/`32px` for sparser, `20px` for denser.

## Test plan
- [ ] `make up` and visit the home page — confirm dots are visible in the canvas around cards, not behind the sidebar.
- [ ] Visit `/accounts/login/` while logged out — confirm dots show on the white login surface.
- [ ] Check at mobile width — sidebar slides off-canvas; dots should still render under the main content.
- [ ] Confirm cards (white `--color-canvas` surfaces) still read cleanly on top of the patterned canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)