### PR TITLE
fix: catch duplicate-submission crashes in ContractExecutionActivity, Favored, ResourceSource

### DIFF
--- a/accountability/views.py
+++ b/accountability/views.py
@@ -89,6 +89,7 @@ from utils.mixins import (
     CommitteeMemberUpdateMixin,
     UserAccessViewMixin,
 )
+from utils.regex import only_digits
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +178,24 @@ class ResourceSourceCreateView(
     def post(self, request, *args, **kwargs):
         form = ResourceSourceForm(request.POST)
         if form.is_valid():
+            # `organization` is excluded from the form (assigned from the
+            # logged-in user, not user input). ResourceSourceForm.clean()
+            # only checks (name, document), not the (organization, document)
+            # pair the model's own clean()/save() and DB constraint actually
+            # enforce - two sources with the same document but different
+            # names slip past the form check and only hit the model's check
+            # inside save(), which this view never wraps in a try/except, so
+            # a genuine duplicate raises an uncaught ValidationError instead
+            # of a friendly form error. Check by hand first.
+            source_exists = ResourceSource.objects.filter(
+                organization=request.user.organization,
+                document=only_digits(form.cleaned_data["document"]),
+            ).exists()
+            if source_exists:
+                return self.render_to_response(
+                    self.get_context_data(form=form, source_exists=True)
+                )
+
             with db_transaction.atomic():
                 source = form.save(commit=False)
                 source.organization = request.user.organization
@@ -838,6 +857,24 @@ class FavoredCreateView(CommitteeMemberCreateMixin, LoginRequiredMixin, Template
     def post(self, request, *args, **kwargs):
         form = FavoredForm(request.POST)
         if form.is_valid():
+            # `organization` is excluded from the form (assigned from the
+            # logged-in user, not user input). FavoredForm.clean() only
+            # checks (name, document), not the (organization, document) pair
+            # the model's own clean()/save() and DB constraint actually
+            # enforce - two favoreds with the same document but different
+            # names slip past the form check and only hit the model's check
+            # inside save(), which this view never wraps in a try/except, so
+            # a genuine duplicate raises an uncaught ValidationError instead
+            # of a friendly form error. Check by hand first.
+            favored_exists = Favored.objects.filter(
+                organization=request.user.organization,
+                document=only_digits(form.cleaned_data["document"]),
+            ).exists()
+            if favored_exists:
+                return self.render_to_response(
+                    self.get_context_data(form=form, favored_exists=True)
+                )
+
             with db_transaction.atomic():
                 favored = form.save(commit=False)
                 favored.organization = request.user.organization

--- a/contracts/views.py
+++ b/contracts/views.py
@@ -910,6 +910,28 @@ def create_execution_activity_view(request, pk):
     if request.method == "POST":
         form = ContractExecutionActivityForm(request.POST, execution=execution)
         if form.is_valid():
+            # `execution` is excluded from the form (assigned from the URL,
+            # not user input), so Django's automatic validate_unique() skips
+            # unique_activity_per_execution_step outright (see the analogous
+            # comment on accountability.views.create_budget_commitment_view) -
+            # check by hand instead of letting a genuine duplicate raise a
+            # raw IntegrityError.
+            activity_exists = ContractExecutionActivity.objects.filter(
+                execution=execution,
+                step=form.cleaned_data["step"],
+                name=form.cleaned_data["name"],
+            ).exists()
+            if activity_exists:
+                return render(
+                    request,
+                    "contracts/execution/activity-create.html",
+                    {
+                        "execution": execution,
+                        "form": form,
+                        "activity_exists": True,
+                    },
+                )
+
             with transaction.atomic():
                 activity = form.save(commit=False)
                 activity.execution = execution
@@ -954,6 +976,24 @@ class ContractExecutionActivityUpdateView(
         return kwargs
 
     def form_valid(self, form):
+        # Same excluded-field gap as create_execution_activity_view:
+        # `execution` isn't a form field, so Django's automatic
+        # validate_unique() skips unique_activity_per_execution_step
+        # outright - check by hand.
+        exists = (
+            ContractExecutionActivity.objects.filter(
+                execution=self.object.execution,
+                step=form.cleaned_data["step"],
+                name=form.cleaned_data["name"],
+            )
+            .exclude(pk=self.object.pk)
+            .exists()
+        )
+        if exists:
+            return self.render_to_response(
+                self.get_context_data(form=form, activity_exists=True)
+            )
+
         _ = ActivityLog.objects.create(
             user=self.request.user,
             user_email=self.request.user.email,

--- a/templates/accountability/favoreds/create.html
+++ b/templates/accountability/favoreds/create.html
@@ -34,6 +34,16 @@
       </div>
     </section>
 
+    {% if favored_exists %}
+      <div class="form-errors" role="alert">
+        <div class="form-errors__indicator" aria-hidden="true"></div>
+        <div class="form-errors__body">
+          <p class="ui-body-md-strong form-errors__title">Erro ao criar favorecido</p>
+          <p class="form-errors__item">Já existe um favorecido com este documento nesta organização.</p>
+        </div>
+      </div>
+    {% endif %}
+
     {% include 'commons/form-errors.html' with form=form %}
 
     <div class="ui-row ui-row--end" style="gap: 8px;">

--- a/templates/accountability/sources/create.html
+++ b/templates/accountability/sources/create.html
@@ -30,6 +30,16 @@
       </div>
     </section>
 
+    {% if source_exists %}
+      <div class="form-errors" role="alert">
+        <div class="form-errors__indicator" aria-hidden="true"></div>
+        <div class="form-errors__body">
+          <p class="ui-body-md-strong form-errors__title">Erro ao criar fonte</p>
+          <p class="form-errors__item">Já existe uma fonte com este documento nesta organização.</p>
+        </div>
+      </div>
+    {% endif %}
+
     {% include 'commons/form-errors.html' with form=form %}
 
     <div class="ui-row ui-row--end" style="gap: 8px;">

--- a/templates/contracts/execution/activity-create.html
+++ b/templates/contracts/execution/activity-create.html
@@ -44,6 +44,16 @@
       </div>
     </section>
 
+    {% if activity_exists %}
+      <div class="form-errors" role="alert">
+        <div class="form-errors__indicator" aria-hidden="true"></div>
+        <div class="form-errors__body">
+          <p class="ui-body-md-strong form-errors__title">Erro ao criar atividade</p>
+          <p class="form-errors__item">Já existe uma atividade com este nome nesta etapa.</p>
+        </div>
+      </div>
+    {% endif %}
+
     {% include 'commons/form-errors.html' with form=form %}
 
     <div class="ui-row ui-row--end" style="gap: 8px;">


### PR DESCRIPTION
## Summary

Follow-up sweep for the excluded-field-vs-`UniqueConstraint` bug found while building the AUDESP Fase V CRUD UI (f6776d7): a `UniqueConstraint` whose fields include an FK that's excluded from the corresponding `ModelForm` (assigned from the URL/request instead of user input) makes Django's automatic `validate_unique()` skip that constraint entirely, so a genuine duplicate crashes to a raw exception instead of a clean form error.

Checked every other `UniqueConstraint` in `contracts/models.py` and `accountability/models.py` this session didn't already touch. Three more real bugs, two false alarms (already guarded), four not affected (no user-facing view, or no constraint at all):

**Fixed:**
- `create_execution_activity_view` / `ContractExecutionActivityUpdateView` (`ContractExecutionActivity`) — same mechanism as the original bug: `execution` excluded from `ContractExecutionActivityForm`, duplicate raised a raw `IntegrityError`.
- `FavoredCreateView` (`Favored`) and `ResourceSourceCreateView` (`ResourceSource`) — a related but distinct mechanism: `FavoredForm`/`ResourceSourceForm` each define their own `clean()` checking `(name, document)`, not the `(organization, document)` pair the model's real constraint (and its own `clean()`-in-`save()` override) enforces. Same document + different name slips the form check, then raises an uncaught `ValidationError` from `save()`, which the view never wraps in try/except.

Fix pattern matches the one already established for `BudgetCommitment`/`SupplierContract`/`CertificateReference`: an explicit `.exists()` pre-check before save (plus `.exclude(pk=...)` on the update-view counterpart), and a template banner gated on a boolean context flag.

**Already safe, left untouched:** `create_contract_execution_view` (`ContractExecution`) and the base `AnnualStatement` create view already had the `.exists()` guard.

**Not affected:** `ContractGoalAnnualResult`, `ContractGoalPeriodResult`, `BankBalance` have no user-facing create/update view at all (admin-only/unbuilt). `ConclusiveOpinionDeclaration` is only ever created via `get_or_create` over a fixed 7-choice enum — no path to a new duplicate pair. `Expense`/`Revenue` have no `UniqueConstraint` at all.

All three fixed bugs were empirically reproduced via Django's test `Client` (two-POST collision) before the fix (confirmed 500) and after (confirmed clean 200 + banner) — not just inferred from reading the code.

## Test plan

- [x] Reproduced all three bugs with a throwaway Django test-client script (500 before fix, 200-with-banner after)
- [x] Full `accounts`+`audesp`+`accountability`+`contracts` test suite passes (23 tests)
- [x] `ruff check` / `ruff format --check` clean on the touched files
- [x] No model changes, so no migration needed
- [ ] Manual click-through in a browser (not done this session — recommend exercising the three "create" flows with a genuine duplicate before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)