### PR TITLE
docs: reduce AGENTS.md to a pointer at CLAUDE.MD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+The working guide for this repository is **[`CLAUDE.MD`](CLAUDE.MD)**. Read it before coding.
+
+It is the canonical source for stack, commands, Django conventions, UI density rules, and product tone, and it applies to every agent — not only Claude Code. Pair it with **[`DESIGN.md`](DESIGN.md)** for product and design context.
+
+This file is a pointer on purpose. It used to duplicate `CLAUDE.MD` in full and drifted out of sync, so the same guidance lived in two places and disagreed. Add durable project conventions to `CLAUDE.MD` instead, and leave this file as a signpost.


### PR DESCRIPTION
## Why

`AGENTS.md` had been sitting untracked in the working directory since 2026-05-30 — a 170-line, near-verbatim copy of `CLAUDE.MD`. It had already drifted in the two ways duplicated docs always do:

- **A binding rule went missing.** The "Code is English-only" convention (`CLAUDE.MD:82`) was added after the copy was made and never propagated. An agent reading only `AGENTS.md` would not know that model fields, choice members, and method names must be English even in this Brazilian-Portuguese domain — exactly the rule most likely to be violated in AUDESP/TCE work.
- **One paragraph was nonsense.** The case-insensitivity note survived the find-and-replace as "keep this single filename (`AGENTS.md`). Do not add a separate root `AGENTS.md` symlink or duplicate" — a sentence that made sense only for the `CLAUDE.MD` / `CLAUDE.md` pair it was copied from.

The real defect is having two long guides that must be manually kept in sync. Fixing the drift would just reset the clock on it.

## What

`AGENTS.md` becomes a short pointer at `CLAUDE.MD` (the canonical guide) and `DESIGN.md`. Agents that look for `AGENTS.md` by convention still find their way in; there is now one document to maintain and no drift surface.

`CLAUDE.MD` is unchanged — it already reads as agent-agnostic guidance rather than Claude-specific instructions.

## Verified

- Both relative links resolve: `CLAUDE.MD` and `DESIGN.md` exist at the repo root.
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)