### PR TITLE
feat(ui): skip link, visually-hidden utility and shell padding token

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,10 @@
     :root {
       --sidebar-width-expanded: 256px;
       --sidebar-width-collapsed: 72px;
+      /* Total vertical padding on .shell__main. Full-height pages size
+         themselves with calc(100dvh - var(--shell-main-pad-y)); keep this in
+         sync with the .shell__main padding rules below. */
+      --shell-main-pad-y: 104px;
     }
 
     /* === Shell ============================================================ */
@@ -51,6 +55,7 @@
       transition: margin-left 220ms ease;
     }
     @media (min-width: 640px) {
+      :root { --shell-main-pad-y: 80px; }
       .shell__main {
         margin-left: var(--sidebar-width-expanded);
         padding: 32px 32px 48px;
@@ -572,6 +577,9 @@
 
 <body class="shell">
 
+  {# Keyboard users reach the page content without tabbing the whole sidebar. #}
+  <a href="#main" class="ui-skip-link">Ir para o conteúdo</a>
+
   {# === Loader overlay (toggled via .hidden by form-submit JS) === #}
   <div id="loader-overlay" class="hidden shell__loader-backdrop" role="status" aria-live="polite">
     <div class="shell__loader-card">
@@ -784,7 +792,7 @@
   </aside>
   {% endwith %}
 
-  <main class="shell__main">
+  <main class="shell__main" id="main">
     {% block content %}{% endblock %}
   </main>
 

--- a/templates/ui/_styles.html
+++ b/templates/ui/_styles.html
@@ -87,6 +87,27 @@ geometric display sans, sentence-case voice).
     text-rendering: optimizeLegibility;
   }
 
+  /* === Skip link === */
+  .ui-skip-link {
+    position: fixed;
+    /* Parked off-screen via `top` rather than `transform`: nothing else can
+       compose with it, and it survives any ancestor stacking context. */
+    top: -120px;
+    left: 8px;
+    z-index: 10000;
+    padding: 10px 18px;
+    border-radius: var(--rounded-pill);
+    background-color: var(--color-primary);
+    color: var(--color-on-primary);
+    font-family: var(--font-text);
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 16px;
+    text-decoration: none;
+    transition: top 140ms ease;
+  }
+  .ui-skip-link:focus { top: 8px; outline: none; box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.25); }
+
   /* === Typography utility classes === */
   .ui-display-xxl { font-family: var(--font-display); font-weight: 700; font-size: 52px; line-height: 64px; letter-spacing: 0; color: var(--color-ink); margin: 0; }
   .ui-display-xl  { font-family: var(--font-display); font-weight: 700; font-size: 36px; line-height: 44px; color: var(--color-ink); margin: 0; }
@@ -439,7 +460,24 @@ geometric display sans, sentence-case voice).
   .ui-row--end        { justify-content: flex-end; }
 
   .ui-text-muted   { color: var(--color-body); }
-  .ui-text-mute    { color: var(--color-mute); }
+  /* `--color-mute` (#afafaf) is a *decorative* token — as text it lands at
+     1.9:1 on canvas-soft, well under the 4.5:1 AA floor. Both text utilities
+     therefore resolve to --color-body; keep --color-mute for separators,
+     dividers and icon chrome only. */
+  .ui-text-mute    { color: var(--color-body); }
+  /* Available to assistive tech, invisible on screen. For labelling a control
+     whose purpose is already obvious from an adjacent visible heading. */
+  .ui-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   .ui-text-center  { text-align: center; }
   .ui-text-right   { text-align: right; }
   .ui-text-truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
**Stack 1/7** — base `main`. Each PR targets the one before it.

Three shared-layer additions any full-height or keyboard-navigable page needs.

| Change | Why |
|---|---|
| `.ui-skip-link` + anchor in `base.html` | The sidebar puts **16 links** ahead of page content in the tab order with no way past them. |
| `.ui-visually-hidden` | For labelling a control whose purpose is already clear from an adjacent visible heading. |
| `--shell-main-pad-y` | Exposes the total vertical padding on `.shell__main` so a page can size itself with `calc(100dvh - var(--shell-main-pad-y))` instead of hardcoding a guess (32px top / 48px bottom on desktop, 72/32 on mobile). |

Also repoints `.ui-text-mute` from `--color-mute` (#afafaf) to `--color-body`. As text on the canvas-soft fill #afafaf measures **1.9:1**, against the 4.5:1 WCAG AA floor. `--color-mute` stays for decorative use (separators, dividers, icon chrome).

## Verification
`manage.py check` clean. Skip link verified in-browser: parked at `top: -120px`, the `:focus` rule resolves to `top: 8px`, and at that value it lands fully on-screen at 8,8 with a 158×36 target. `.ui-text-mute` now computes `rgb(94,94,94)`.

⚠️ **`:focus` itself was not exercised** — `document.hasFocus()` is false in a headless pane, so `:focus` can never match there. Worth one real keyboard Tab before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)