### PR TITLE
fix(a11y): raise placeholder contrast to meet WCAG AA

### DIFF
--- a/templates/ui/_styles.html
+++ b/templates/ui/_styles.html
@@ -284,8 +284,11 @@ geometric display sans, sentence-case voice).
   }
   /* Hide IE's native arrow */
   select.ui-input::-ms-expand { display: none; }
+  /* --color-body, not --color-mute: #afafaf placeholders land at 1.9:1 on the
+     canvas-soft fill, well under the 4.5:1 AA floor. Placeholder text is in
+     scope for WCAG 1.4.3. */
   input.ui-input::placeholder,
-  textarea.ui-input::placeholder { color: var(--color-mute); }
+  textarea.ui-input::placeholder { color: var(--color-body); }
   input.ui-input:hover,
   textarea.ui-input:hover,
   select.ui-input:hover { background-color: var(--color-surface-pressed); }
@@ -387,7 +390,7 @@ geometric display sans, sentence-case voice).
     resize: vertical;
     transition: border-color 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
   }
-  .ui-textarea::placeholder { color: var(--color-mute); }
+  .ui-textarea::placeholder { color: var(--color-body); }
   .ui-textarea:hover { background-color: var(--color-surface-pressed); }
   .ui-textarea:focus {
     border-color: var(--color-ink);


### PR DESCRIPTION
**Stack 2/7** — base `feat/shell-a11y-tokens` (#53).

Placeholders resolved to `--color-mute` (#afafaf):

| Text | On | Ratio | AA (4.5:1) |
|---|---|---|---|
| `--color-mute` #afafaf | white | 2.19:1 | ❌ |
| `--color-mute` #afafaf | canvas-soft #efefef | **1.91:1** | ❌ |
| `--color-body` #5e5e5e | canvas-soft #efefef | **5.64:1** | ✅ |

Placeholder text is in scope for WCAG 1.4.3. Repointed to `--color-body` — already a declared token in `DESIGN.md`, so this introduces no new value. #6d6d6d is the lightest passing value on #efefef and sits right on the 4.5 boundary, which is too tight to rely on.

`--color-mute` is untouched for its decorative uses (`.ui-breadcrumb__sep`, `.paginator__btn--disabled`, and the sidebar colours, which sit on #000000 and pass comfortably).

## Verification
Measured in-browser on `/contracts/company/create/`: placeholder computes `rgb(94,94,94)` on a `#efefef` fill = **5.64:1**. Placeholders remain visibly distinct from entered values (#000).

## Note
You started a background task for this same finding, so a parallel session may also implement it. Deliberately isolated as its own PR so it can be dropped from the stack without disturbing anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)