### PR TITLE
refactor(ui): drop Tailwind utility classes from the shared form widgets

### DIFF
--- a/templates/ui/_styles.html
+++ b/templates/ui/_styles.html
@@ -789,6 +789,29 @@ geometric display sans, sentence-case voice).
     cursor: pointer;
   }
   .ui-form textarea:not(.ui-textarea) { min-height: 120px; resize: vertical; padding: 16px; }
+  /* The Django widgets in utils.widgets carry no utility classes, so their
+     placeholder colour has to come from here. AA-compliant (5.6:1 on the
+     canvas-soft fill) — see the note on input.ui-input::placeholder. */
+  .ui-form input:not(.ui-input):not(.file-drop-zone__input)::placeholder,
+  .ui-form textarea:not(.ui-textarea)::placeholder { color: var(--color-body); }
+
+  /* File input — the only Django-rendered control the rules above do not
+     cover, since input[type=file] needs its own affordance. */
+  .ui-form input[type="file"]:not(.file-drop-zone__input) {
+    width: 100%;
+    padding: 10px 12px;
+    min-height: 52px;
+    border-radius: var(--rounded-md);
+    background-color: var(--color-canvas-soft);
+    color: var(--color-ink);
+    font-family: var(--font-text);
+    font-size: 14px;
+    line-height: 20px;
+    border: 1px dashed var(--color-hairline-mid);
+    cursor: pointer;
+  }
+  .ui-form input[type="file"]:not(.file-drop-zone__input):hover { background-color: var(--color-surface-pressed); }
+  .ui-form input[type="file"]:not(.file-drop-zone__input):focus { outline: none; border-color: var(--color-ink); border-style: solid; }
   .ui-form input:not(.ui-input):not(.file-drop-zone__input):hover,
   .ui-form select:not(.ui-select):hover,
   .ui-form textarea:not(.ui-textarea):hover { background-color: var(--color-surface-pressed); }

--- a/utils/widgets.py
+++ b/utils/widgets.py
@@ -13,26 +13,6 @@ class BaseCharFieldFormWidget(forms.TextInput):
     ):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
                 "required": required,
             }
         )
@@ -49,26 +29,6 @@ class BaseDateFormWidget(forms.DateInput):
     def __init__(self, *args, placeholder="dd/mm/aaaa", required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
                 "required": required,
                 "placeholder": placeholder,
                 "datepicker": "",
@@ -84,26 +44,6 @@ class BaseNumberFormWidget(forms.NumberInput):
     def __init__(self, *args, placeholder=None, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
                 "required": required,
             }
         )
@@ -117,27 +57,6 @@ class BaseTextAreaFormWidget(forms.Textarea):
     def __init__(self, *args, placeholder=None, required=True, rows=3, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                        "resize-vertical",
-                    ]
-                ),
                 "rows": rows,
                 "required": required,
             }
@@ -152,25 +71,6 @@ class BaseSelectFormWidget(forms.Select):
     def __init__(self, *args, placeholder=None, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
                 "required": required,
             }
         )
@@ -184,22 +84,6 @@ class BaseEmailFormWidget(forms.EmailInput):
     def __init__(self, *args, placeholder=None, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "border",
-                        "text-sm",
-                        "rounded-lg",
-                        "block",
-                        "w-full",
-                        "p-2.5",
-                        "bg-gray-200",
-                        "border-gray-600",
-                        "placeholder-gray-600",
-                        "text-black",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                    ]
-                ),
                 "required": required,
             }
         )
@@ -213,13 +97,6 @@ class BaseFileFormWidget(forms.FileInput):
     def __init__(self, *args, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block w-full text-sm text-gray-900 border",
-                        "border-gray-600 rounded-lg cursor-pointer",
-                        "bg-gray-300 focus:outline-none",
-                    ]
-                ),
                 "required": required,
             }
         )
@@ -248,22 +125,6 @@ class CustomPhoneNumberField(PhoneNumberField):
             "widget",
             forms.TextInput(
                 attrs={
-                    "class": " ".join(
-                        [
-                            "w-full",
-                            "p-2.5",
-                            "block",
-                            "text-sm",
-                            "border",
-                            "rounded-lg",
-                            "placeholder-gray-600",
-                            "bg-gray-300",
-                            "border-gray-600",
-                            "text-black",
-                            "focus:ring-blue-500",
-                            "focus:border-blue-500",
-                        ]
-                    ),
                     "placeholder": "(00) 00000-0000",
                     "data-mask": "(00) 00000-0000",
                     "type": "tel",
@@ -279,22 +140,6 @@ class CustomCPFWidget(forms.TextInput):
         kwargs.setdefault(
             "attrs",
             {
-                "class": " ".join(
-                    [
-                        "w-full",
-                        "p-2.5",
-                        "block",
-                        "text-sm",
-                        "border",
-                        "rounded-lg",
-                        "placeholder-gray-600",
-                        "bg-gray-300",
-                        "border-gray-600",
-                        "text-black",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                    ]
-                ),
                 "placeholder": "000.000.000-00",
                 "data-mask": "000.000.000-00",
                 "type": "text",
@@ -309,22 +154,6 @@ class CustomCNPJWidget(forms.TextInput):
         kwargs.setdefault(
             "attrs",
             {
-                "class": " ".join(
-                    [
-                        "w-full",
-                        "p-2.5",
-                        "block",
-                        "text-sm",
-                        "border",
-                        "rounded-lg",
-                        "placeholder-gray-600",
-                        "bg-gray-300",
-                        "border-gray-600",
-                        "text-black",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                    ]
-                ),
                 "placeholder": "00.000.000/0000-00",
                 "data-mask": "00.000.000/0000-00",
                 "type": "text",


### PR DESCRIPTION
**Stack 3/7** — base `design/placeholder-contrast`.

Every `Base*`/`Custom*` widget in `utils/widgets.py` hardcoded a Tailwind class string:

```
bg-gray-200 border-gray-300 text-gray-900 placeholder-gray-400
focus:ring-2 focus:ring-blue-500 focus:border-blue-500 …
```

Those declarations were **already dead** — the `.ui-form … :not(.ui-input)` rules in `ui/_styles.html` override all of them, so controls render with the ink/canvas palette. They were also a standing risk: `focus:ring-blue-500` contradicts the `DESIGN.md` palette and reappears on any specificity shift.

## Why this is safe to remove outright
Every consumer renders inside a `.ui-form`. 31 templates contain a `<form>` without that wrapper, but only three render Django fields at all — `audesp/fase_v/panel.html` and the two reconcile pages — and those use `filter-field__control` and `CustomCheckboxSelectMultiple`, neither touched here.

```bash
for f in $(grep -rl "<form" templates/); do grep -q "ui-form" "$f" || echo "$f"; done
```

Two rules move into the stylesheet to cover what Tailwind was incidentally providing:
- a placeholder colour for Django-rendered fields (they now carry no class at all)
- a real style for `input[type=file]`, the one control the generic rules don't match

## Verification
Measured on `/contracts/company/create/`: **0** Tailwind classes remaining, geometry **unchanged at 52px**, `#efefef` fill, transparent border, 8px radius — identical to before. Masks, placeholders, `inputmode` and datepicker attributes all preserved. `manage.py check` and `ruff` clean.

Chose this over emitting `.ui-input`, which would have grown every field 52px → 56px across the app.

## Note
You started a background task for this finding too, so a parallel session may also implement it — isolated so it can be dropped independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)