### PR TITLE
feat(ui): shared searchable combobox component

### DIFF
--- a/templates/ui/_combobox_control.html
+++ b/templates/ui/_combobox_control.html
@@ -1,0 +1,82 @@
+{% comment %}
+ui/_combobox_control.html — the combobox control itself, without the field
+wrapper (no label, hint or error). Included by both `ui/combobox.html` (the
+include-API component) and `ui/combobox_widget.html` (the Django widget), so
+the two share a single implementation.
+
+Expects the caller to have resolved: wrapper_id, name, ph, url, options, value,
+selected_text, search_placeholder, empty_text, page_size, size, surface,
+disabled, error.
+{% endcomment %}
+<div
+  class="ui-combobox{% if size == 'sm' %} ui-combobox--sm{% endif %}{% if surface == 'softer' %} ui-combobox--on-soft{% endif %}"
+  id="{{ wrapper_id }}"
+  data-ui-combobox
+  {% if url %}data-url="{{ url }}"{% endif %}
+  data-page-size="{{ page_size|default:10 }}"
+  data-placeholder="{{ ph }}"
+  data-empty-text="{{ empty_text|default:'Nenhum resultado' }}"
+>
+  <input
+    type="hidden"
+    name="{{ name }}"
+    id="{{ wrapper_id }}-input"
+    value="{{ value|default_if_none:'' }}"
+    data-ui-combobox-input
+  />
+
+  <button
+    type="button"
+    class="ui-combobox__trigger"
+    id="{{ wrapper_id }}-trigger"
+    aria-haspopup="listbox"
+    aria-expanded="false"
+    aria-controls="{{ wrapper_id }}-panel"
+    {% if error %}aria-invalid="true" aria-describedby="{{ wrapper_id }}-error"{% endif %}
+    {% if disabled %}disabled{% endif %}
+    data-ui-combobox-trigger
+  >
+    <span
+      class="ui-combobox__value{% if not selected_text %} ui-combobox__value--placeholder{% endif %}"
+      data-ui-combobox-value
+      data-selected-text="{{ selected_text|default_if_none:'' }}"
+    >{% if selected_text %}{{ selected_text }}{% else %}{{ ph }}{% endif %}</span>
+  </button>
+
+  <div class="ui-combobox__panel" id="{{ wrapper_id }}-panel" data-ui-combobox-panel>
+    <div class="ui-combobox__search-wrap">
+      <span class="ui-combobox__search-icon" aria-hidden="true">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+      </span>
+      <input
+        type="text"
+        class="ui-combobox__search"
+        role="combobox"
+        aria-expanded="true"
+        aria-controls="{{ wrapper_id }}-list"
+        aria-autocomplete="list"
+        aria-activedescendant=""
+        aria-label="{{ search_placeholder|default:'Buscar' }}"
+        placeholder="{{ search_placeholder|default:'Buscar…' }}"
+        autocomplete="off"
+        data-ui-combobox-search
+      />
+    </div>
+
+    <ul
+      class="ui-combobox__list"
+      id="{{ wrapper_id }}-list"
+      role="listbox"
+      aria-label="{{ ph }}"
+      data-ui-combobox-list
+    ></ul>
+
+    <p class="ui-combobox__status" role="status" hidden data-ui-combobox-status></p>
+  </div>
+
+  {% comment %}
+    Static mode payload. `json_script` is the built-in filter — it escapes the
+    closing script tag, so options cannot break out of the element.
+  {% endcomment %}
+  {% if not url %}{{ options|json_script }}{% endif %}
+</div>

--- a/templates/ui/_scripts.html
+++ b/templates/ui/_scripts.html
@@ -7,6 +7,7 @@ Include once near the bottom of any page that uses the UI components:
 Provides:
   • Password show/hide toggle (data-ui-password-toggle="<input-id>")
   • window.UIToast.show({ message, variant, position, duration })
+  • window.UICombobox — searchable/paginated select (see ui/combobox.html)
 {% endcomment %}
 
 <script>
@@ -196,6 +197,399 @@ Provides:
     document.addEventListener('DOMContentLoaded', drainQueuedToasts);
   } else {
     drainQueuedToasts();
+  }
+})();
+</script>
+
+<script>
+/* ==================================================================== *
+ * Combobox runtime — window.UICombobox                                 *
+ *                                                                      *
+ * Searchable replacement for a native <select>. Two modes, chosen by    *
+ * the presence of data-url:                                            *
+ *                                                                      *
+ *   remote  — data-url points at a ComboboxSearchView. The first page   *
+ *             (data-page-size items, default 10) loads on first open,   *
+ *             never on page load; typing refetches with ?q=; scrolling  *
+ *             to the bottom of the list fetches ?page=N+1. The full     *
+ *             option set is NEVER serialized into the page.             *
+ *   static  — options come from the inline application/json <script>    *
+ *             payload (rendered by the `json_script` filter) and are     *
+ *             filtered client-side. No requests.                        *
+ *                                                                      *
+ * The selected value lives in a hidden <input>, so Django form handling *
+ * is unchanged; ModelChoiceField still validates against its queryset.  *
+ * ==================================================================== */
+(function () {
+  var SEARCH_DEBOUNCE_MS = 250;
+  var registry = new WeakMap();
+
+  /* Case- and accent-insensitive fold, so "saude" matches "Saúde" and
+     "convenio" matches "convênio". Mirrors the server side, which uses the
+     Postgres `unaccent` lookup — static mode must behave the same as remote. */
+  function fold(value) {
+    var text = String(value == null ? '' : value).toLowerCase();
+    if (!text.normalize) return text;
+    // \u0300-\u036f is the combining diacritical marks block.
+    return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  }
+
+  function parseJSONScript(root, selector) {
+    var node = root.querySelector(selector);
+    if (!node) return null;
+    try {
+      return JSON.parse(node.textContent || 'null');
+    } catch (e) {
+      if (window.console) console.warn('[UICombobox] invalid options payload', e);
+      return null;
+    }
+  }
+
+  function create(root) {
+    if (registry.has(root)) return registry.get(root);
+
+    var trigger = root.querySelector('[data-ui-combobox-trigger]');
+    var valueEl = root.querySelector('[data-ui-combobox-value]');
+    var hidden = root.querySelector('[data-ui-combobox-input]');
+    var panel = root.querySelector('[data-ui-combobox-panel]');
+    var search = root.querySelector('[data-ui-combobox-search]');
+    var list = root.querySelector('[data-ui-combobox-list]');
+    var status = root.querySelector('[data-ui-combobox-status]');
+    if (!trigger || !valueEl || !hidden || !panel || !list) return null;
+
+    var url = root.getAttribute('data-url') || '';
+    var pageSize = parseInt(root.getAttribute('data-page-size') || '10', 10) || 10;
+    var placeholder = root.getAttribute('data-placeholder') || 'Selecione';
+    var emptyText = root.getAttribute('data-empty-text') || 'Nenhum resultado';
+    var isStatic = !url;
+    var staticItems = isStatic
+      ? (parseJSONScript(root, 'script[type="application/json"]') || [])
+      : null;
+
+    var initialValue = hidden.value || '';
+    var initialLabel = valueEl.getAttribute('data-selected-text') || '';
+
+    var items = [];
+    var optionEls = [];
+    var activeIndex = -1;
+    var page = 1;
+    var hasMore = false;
+    var loading = false;
+    var query = '';
+    var open = false;
+    var controller = null;
+    var debounceId = null;
+
+    /* --- status line ------------------------------------------------- */
+    function setStatus(text, variant) {
+      if (!status) return;
+      status.textContent = text || '';
+      status.hidden = !text;
+      status.classList.toggle('ui-combobox__status--error', variant === 'error');
+    }
+
+    function setLoadingRow(on) {
+      if (!status) return;
+      if (on) {
+        status.hidden = false;
+        status.classList.remove('ui-combobox__status--error');
+        status.innerHTML = '<span class="ui-combobox__spinner" aria-hidden="true"></span><span>Carregando…</span>';
+      } else if (!status.textContent.trim() || status.querySelector('.ui-combobox__spinner')) {
+        status.hidden = true;
+        status.textContent = '';
+      }
+    }
+
+    /* --- rendering --------------------------------------------------- */
+    function renderList() {
+      list.innerHTML = '';
+      optionEls = [];
+      var lastGroup = null;
+
+      items.forEach(function (item, index) {
+        if (item.group && item.group !== lastGroup) {
+          lastGroup = item.group;
+          var groupEl = document.createElement('li');
+          groupEl.className = 'ui-combobox__group';
+          groupEl.setAttribute('role', 'presentation');
+          groupEl.textContent = item.group;
+          list.appendChild(groupEl);
+        }
+
+        var li = document.createElement('li');
+        li.className = 'ui-combobox__option';
+        li.id = root.id + '-opt-' + index;
+        li.setAttribute('role', 'option');
+        li.setAttribute('data-value', String(item.id));
+        li.setAttribute('aria-selected', String(item.id) === hidden.value ? 'true' : 'false');
+
+        var text = document.createElement('span');
+        text.className = 'ui-combobox__option-text';
+        text.textContent = item.text;
+        li.appendChild(text);
+
+        if (item.subtext) {
+          var sub = document.createElement('span');
+          sub.className = 'ui-combobox__option-sub';
+          sub.textContent = item.subtext;
+          li.appendChild(sub);
+        }
+
+        li.addEventListener('mousedown', function (ev) {
+          // mousedown (not click) so the panel closes before the search
+          // input's blur handler can race the selection.
+          ev.preventDefault();
+          selectIndex(index);
+        });
+        list.appendChild(li);
+        optionEls.push(li);
+      });
+
+      if (!items.length && !loading) setStatus(emptyText);
+      else if (!loading) setStatus('');
+
+      setActiveIndex(items.length ? 0 : -1);
+      // A page that does not fill the list leaves nothing to scroll, so keep
+      // pulling pages until the list overflows or the server runs dry.
+      // setTimeout, not requestAnimationFrame: rAF is suspended while the
+      // document is hidden, which would stall the chain in a background tab.
+      if (hasMore) window.setTimeout(maybeLoadMore, 0);
+    }
+
+    function maybeLoadMore() {
+      if (!hasMore || loading || !open) return;
+      var remaining = list.scrollHeight - list.scrollTop - list.clientHeight;
+      // A short list has remaining === 0 and can never scroll — load anyway.
+      if (remaining < 80) loadPage(page + 1);
+    }
+
+    function setActiveIndex(index) {
+      activeIndex = index;
+      optionEls.forEach(function (el, i) {
+        el.classList.toggle('ui-combobox__option--active', i === index);
+      });
+      if (search) {
+        search.setAttribute(
+          'aria-activedescendant',
+          index >= 0 && optionEls[index] ? optionEls[index].id : ''
+        );
+      }
+      if (index >= 0 && optionEls[index]) {
+        optionEls[index].scrollIntoView({ block: 'nearest' });
+      }
+    }
+
+    /* --- data ------------------------------------------------------- */
+    function matchesQuery(item, q) {
+      if (!q) return true;
+      var needle = fold(q);
+      return fold(item.text).indexOf(needle) !== -1
+        || fold(item.subtext).indexOf(needle) !== -1
+        || fold(item.group).indexOf(needle) !== -1;
+    }
+
+    function loadStatic() {
+      items = staticItems.filter(function (item) { return matchesQuery(item, query); });
+      hasMore = false;
+      renderList();
+    }
+
+    function loadPage(targetPage) {
+      if (isStatic) return loadStatic();
+      if (loading) return;
+      loading = true;
+      if (targetPage === 1) setStatus('');
+      setLoadingRow(true);
+
+      if (controller) controller.abort();
+      controller = ('AbortController' in window) ? new AbortController() : null;
+
+      var qs = '?q=' + encodeURIComponent(query)
+        + '&page=' + targetPage
+        + '&page_size=' + pageSize;
+
+      fetch(url + qs, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
+        credentials: 'same-origin',
+        signal: controller ? controller.signal : undefined
+      }).then(function (res) {
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+      }).then(function (data) {
+        loading = false;
+        setLoadingRow(false);
+        page = data.page || targetPage;
+        hasMore = !!data.has_more;
+        var results = Array.isArray(data.results) ? data.results : [];
+        items = targetPage === 1 ? results : items.concat(results);
+        renderList();
+      }).catch(function (err) {
+        if (err && err.name === 'AbortError') return;
+        loading = false;
+        setLoadingRow(false);
+        setStatus('Não foi possível carregar. Tente novamente.', 'error');
+      });
+    }
+
+    function scheduleSearch() {
+      if (debounceId) window.clearTimeout(debounceId);
+      debounceId = window.setTimeout(function () {
+        debounceId = null;
+        page = 1;
+        if (isStatic) loadStatic();
+        else loadPage(1);
+      }, isStatic ? 0 : SEARCH_DEBOUNCE_MS);
+    }
+
+    /* --- selection --------------------------------------------------- */
+    function applySelection(value, label) {
+      hidden.value = value == null ? '' : String(value);
+      if (label) {
+        valueEl.textContent = label;
+        valueEl.classList.remove('ui-combobox__value--placeholder');
+      } else {
+        valueEl.textContent = placeholder;
+        valueEl.classList.add('ui-combobox__value--placeholder');
+      }
+      valueEl.setAttribute('data-selected-text', label || '');
+      hidden.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    function selectIndex(index) {
+      var item = items[index];
+      if (!item) return;
+      applySelection(item.id, item.text);
+      closePanel(true);
+    }
+
+    /* --- open/close -------------------------------------------------- */
+    function positionPanel() {
+      root.classList.remove('ui-combobox--drop-up');
+      var rect = trigger.getBoundingClientRect();
+      var panelHeight = panel.offsetHeight || 280;
+      if (rect.bottom + panelHeight + 8 > window.innerHeight && rect.top > panelHeight) {
+        root.classList.add('ui-combobox--drop-up');
+      }
+    }
+
+    function openPanel() {
+      if (open) return;
+      open = true;
+      root.classList.add('ui-combobox--open');
+      trigger.setAttribute('aria-expanded', 'true');
+      positionPanel();
+      if (search) { search.value = query; search.focus(); }
+      if (isStatic) loadStatic();
+      else if (!items.length) loadPage(1);
+      else renderList();
+    }
+
+    function closePanel(returnFocus) {
+      if (!open) return;
+      open = false;
+      root.classList.remove('ui-combobox--open', 'ui-combobox--drop-up');
+      trigger.setAttribute('aria-expanded', 'false');
+      if (returnFocus) trigger.focus();
+    }
+
+    /* --- events ------------------------------------------------------ */
+    list.addEventListener('scroll', maybeLoadMore);
+
+    trigger.addEventListener('click', function () {
+      if (open) closePanel(true);
+      else openPanel();
+    });
+
+    trigger.addEventListener('keydown', function (ev) {
+      if (ev.key === 'ArrowDown' || ev.key === 'Enter' || ev.key === ' ') {
+        ev.preventDefault();
+        openPanel();
+      }
+    });
+
+    if (search) {
+      search.addEventListener('input', function () {
+        query = search.value.trim();
+        scheduleSearch();
+      });
+
+      search.addEventListener('keydown', function (ev) {
+        switch (ev.key) {
+          case 'ArrowDown':
+            ev.preventDefault();
+            if (optionEls.length) setActiveIndex(Math.min(activeIndex + 1, optionEls.length - 1));
+            break;
+          case 'ArrowUp':
+            ev.preventDefault();
+            if (optionEls.length) setActiveIndex(Math.max(activeIndex - 1, 0));
+            break;
+          case 'Home':
+            if (optionEls.length) { ev.preventDefault(); setActiveIndex(0); }
+            break;
+          case 'End':
+            if (optionEls.length) { ev.preventDefault(); setActiveIndex(optionEls.length - 1); }
+            break;
+          case 'Enter':
+            // Always swallow Enter — otherwise it submits the owning form.
+            ev.preventDefault();
+            if (activeIndex >= 0) selectIndex(activeIndex);
+            break;
+          case 'Escape':
+            ev.preventDefault();
+            closePanel(true);
+            break;
+          case 'Tab':
+            closePanel(false);
+            break;
+        }
+      });
+    }
+
+    document.addEventListener('click', function (ev) {
+      if (open && !root.contains(ev.target)) closePanel(false);
+    });
+
+    var owningForm = root.closest('form');
+    if (owningForm) {
+      owningForm.addEventListener('reset', function () {
+        // Native reset does not touch a hidden input we drive by hand.
+        window.setTimeout(function () {
+          query = '';
+          page = 1;
+          items = [];
+          applySelection(initialValue, initialLabel);
+          closePanel(false);
+        }, 0);
+      });
+    }
+
+    var api = {
+      root: root,
+      open: openPanel,
+      close: function () { closePanel(false); },
+      clear: function () { applySelection('', ''); },
+      getValue: function () { return hidden.value; },
+      setValue: applySelection,
+      refresh: function () { items = []; page = 1; if (open) loadPage(1); }
+    };
+    registry.set(root, api);
+    return api;
+  }
+
+  function initAll(scope) {
+    (scope || document).querySelectorAll('[data-ui-combobox]').forEach(create);
+  }
+
+  window.UICombobox = {
+    init: initAll,
+    create: create,
+    get: function (root) { return registry.get(root) || null; }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { initAll(); });
+  } else {
+    initAll();
   }
 })();
 </script>

--- a/templates/ui/_styles.html
+++ b/templates/ui/_styles.html
@@ -374,6 +374,186 @@ geometric display sans, sentence-case voice).
     box-shadow: 0 0 0 1px var(--color-toast-error) inset;
   }
 
+  /* === Combobox ==============================================================
+     Searchable, paginated replacement for a native <select>. Geometry mirrors
+     .ui-select so the two can sit side by side in the same form. See
+     ui/combobox.html for the include API and window.UICombobox for behaviour. */
+  .ui-combobox { position: relative; width: 100%; }
+
+  .ui-combobox__trigger {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 14px 44px 14px 16px;
+    min-height: 52px;
+    border-radius: var(--rounded-md);
+    background-color: var(--color-canvas-soft);
+    color: var(--color-ink);
+    font-family: var(--font-text);
+    font-size: 16px;
+    line-height: 20px;
+    text-align: left;
+    border: 1px solid transparent;
+    outline: none;
+    cursor: pointer;
+    background-image:
+      url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3E%3Cpath stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.6' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 16px center;
+    background-size: 16px;
+    transition: background-color 140ms ease, box-shadow 140ms ease, border-color 140ms ease;
+  }
+  .ui-combobox__trigger:hover { background-color: var(--color-surface-pressed); }
+  .ui-combobox__trigger:focus-visible,
+  .ui-combobox__trigger[aria-expanded="true"] {
+    border-color: var(--color-ink);
+    background-color: var(--color-canvas);
+    box-shadow: 0 0 0 1px var(--color-ink) inset;
+  }
+  .ui-combobox__trigger[aria-invalid="true"] {
+    border-color: var(--color-toast-error);
+    box-shadow: 0 0 0 1px var(--color-toast-error) inset;
+  }
+  .ui-combobox__trigger:disabled { opacity: 0.6; cursor: not-allowed; }
+  .ui-combobox__trigger:disabled:hover { background-color: var(--color-canvas-soft); }
+
+  /* Dense variant — matches the 36–40px control height used in app forms. */
+  .ui-combobox--sm .ui-combobox__trigger {
+    min-height: 38px;
+    padding: 8px 32px 8px 12px;
+    font-size: 14px;
+    line-height: 18px;
+    background-position: right 10px center;
+    background-size: 14px;
+  }
+  .ui-combobox--on-soft .ui-combobox__trigger { background-color: var(--color-canvas-softer); }
+
+  .ui-combobox__value {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ui-combobox__value--placeholder { color: var(--color-body); }
+
+  /* --- Panel --- */
+  .ui-combobox__panel {
+    position: absolute;
+    z-index: 60;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    display: none;
+    flex-direction: column;
+    background-color: var(--color-canvas);
+    border: 1px solid var(--color-canvas-soft);
+    border-radius: var(--rounded-lg);
+    box-shadow: var(--shadow-1);
+    overflow: hidden;
+  }
+  .ui-combobox--open .ui-combobox__panel { display: flex; }
+  /* Flipped above the trigger when there is no room below. */
+  .ui-combobox--drop-up .ui-combobox__panel { top: auto; bottom: calc(100% + 4px); }
+
+  .ui-combobox__search-wrap {
+    flex-shrink: 0;
+    position: relative;
+    padding: 8px;
+    border-bottom: 1px solid var(--color-canvas-soft);
+  }
+  .ui-combobox__search {
+    width: 100%;
+    min-height: 36px;
+    padding: 8px 12px 8px 34px;
+    border-radius: var(--rounded-md);
+    border: 1px solid transparent;
+    background-color: var(--color-canvas-soft);
+    color: var(--color-ink);
+    font-family: var(--font-text);
+    font-size: 14px;
+    line-height: 18px;
+    outline: none;
+  }
+  .ui-combobox__search::placeholder { color: var(--color-body); }
+  .ui-combobox__search:focus { border-color: var(--color-ink); background-color: var(--color-canvas); }
+  .ui-combobox__search-icon {
+    position: absolute;
+    left: 18px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--color-body);
+    pointer-events: none;
+    display: inline-flex;
+  }
+
+  .ui-combobox__list {
+    flex: 1;
+    margin: 0;
+    padding: 4px;
+    list-style: none;
+    max-height: 240px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+  .ui-combobox__group {
+    padding: 8px 10px 4px;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    color: var(--color-body);
+  }
+  .ui-combobox__option {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 10px;
+    min-height: 36px;
+    border-radius: var(--rounded-md);
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 18px;
+    color: var(--color-ink);
+  }
+  .ui-combobox__option:hover,
+  .ui-combobox__option--active { background-color: var(--color-canvas-soft); }
+  .ui-combobox__option[aria-selected="true"] {
+    background-color: var(--color-primary);
+    color: var(--color-on-primary);
+  }
+  .ui-combobox__option-sub { font-size: 12px; line-height: 16px; color: var(--color-body); }
+  .ui-combobox__option[aria-selected="true"] .ui-combobox__option-sub { color: rgba(255, 255, 255, 0.72); }
+
+  .ui-combobox__status {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 14px 10px;
+    font-size: 13px;
+    line-height: 18px;
+    color: var(--color-body);
+    text-align: center;
+  }
+  .ui-combobox__status--error { color: var(--color-toast-error); }
+
+  .ui-combobox__spinner {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    border: 2px solid var(--color-canvas-soft);
+    border-top-color: var(--color-ink);
+    border-radius: 50%;
+    animation: ui-combobox-spin 700ms linear infinite;
+  }
+  @keyframes ui-combobox-spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) {
+    .ui-combobox__spinner { animation-duration: 2s; }
+    .ui-combobox__trigger { transition: none; }
+  }
+
   /* === Textarea === */
   .ui-textarea {
     width: 100%;

--- a/templates/ui/combobox.html
+++ b/templates/ui/combobox.html
@@ -1,0 +1,59 @@
+{% comment %}
+ui/combobox.html — searchable select. Drop-in replacement for a native
+<select> when the option list is long enough that shipping every <option> in
+the page is wasteful, or when users need to type to find a value.
+
+Two modes:
+
+  remote — pass `url` (a ComboboxSearchView endpoint). Nothing is fetched on
+           page load; the first `page_size` options load when the panel is
+           first opened, typing refetches, scrolling the list loads the next
+           page. Page weight stays constant however large the queryset grows.
+
+  static — pass `options` (an iterable of dicts). Filtered client-side, no
+           requests. Use for fixed choice lists that need search or groups.
+
+Usage — remote:
+    {% include 'ui/combobox.html' with name='contract' label='Contrato' url=contract_options_url placeholder='Selecione um contrato' size='sm' %}
+
+Usage — static, with groups:
+    {% include 'ui/combobox.html' with name='report_model' label='Modelo' options=model_options size='sm' %}
+
+For a Django form field, use utils.widgets.ComboboxSelectWidget instead — it
+renders the same control through ui/combobox_widget.html.
+
+Props (all optional except `name`):
+    name            (str)   form field name.                            REQUIRED
+    id              (str)   wrapper id. Defaults to `id_<name>`.
+    label           (str)   visible label. Omit to render no label.
+    url             (str)   remote endpoint. Presence selects remote mode.
+    options         (iter)  static option dicts: {id, text, subtext, group}.
+    value           (str)   currently selected value.
+    selected_text   (str)   label for `value` — rendered server-side so an
+                            edit form shows the current selection with no fetch.
+    placeholder     (str)   trigger text when nothing is selected.
+    search_placeholder (str) placeholder inside the search box.
+    empty_text      (str)   message when a search returns nothing.
+    page_size       (int)   options per request in remote mode. Default 10.
+    required        (bool)  marks the label with an asterisk.
+    disabled        (bool)  disables the trigger.
+    size            (str)   'sm' for the 38px dense control. Default 52px.
+    surface         (str)   'softer' to sit on a canvas-soft background.
+    error           (str)   error message; also sets aria-invalid on the trigger.
+    hint            (str)   helper text under the control.
+{% endcomment %}
+
+{% with auto_id="id_"|add:name ph=placeholder|default:"Selecione" %}
+{% with wrapper_id=id|default:auto_id %}
+<div class="ui-field">
+  {% if label %}
+    <label class="ui-field__label" for="{{ wrapper_id }}-trigger">{{ label }}{% if required %}<span aria-hidden="true" style="color: var(--color-ink); margin-left:2px;">*</span>{% endif %}</label>
+  {% endif %}
+
+  {% include 'ui/_combobox_control.html' %}
+
+  {% if hint and not error %}<p class="ui-field__hint">{{ hint }}</p>{% endif %}
+  {% if error %}<p class="ui-field__error" id="{{ wrapper_id }}-error">{{ error }}</p>{% endif %}
+</div>
+{% endwith %}
+{% endwith %}

--- a/templates/ui/combobox_widget.html
+++ b/templates/ui/combobox_widget.html
@@ -1,0 +1,8 @@
+{% comment %}
+ui/combobox_widget.html — Django widget template for ComboboxSelectWidget.
+
+Renders the bare control; the label, hint and error come from the surrounding
+form template, exactly as they do for a native <select>. Point the label at
+`{{ field.id_for_label }}` — the widget resolves that to the trigger button.
+{% endcomment %}
+{% include 'ui/_combobox_control.html' with wrapper_id=widget.attrs.id name=widget.name ph=widget.combobox.placeholder url=widget.combobox.url options=widget.combobox.options value=widget.combobox.value selected_text=widget.combobox.selected_text search_placeholder=widget.combobox.search_placeholder empty_text=widget.combobox.empty_text page_size=widget.combobox.page_size size=widget.combobox.size surface=widget.combobox.surface disabled=widget.attrs.disabled error=widget.combobox.error %}

--- a/utils/views.py
+++ b/utils/views.py
@@ -1,0 +1,80 @@
+import logging
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Q, QuerySet
+from django.http import JsonResponse
+from django.views import View
+
+logger = logging.getLogger(__name__)
+
+
+class ComboboxSearchView(LoginRequiredMixin, View):
+    """Paginated JSON option source for the `ui/combobox.html` component.
+
+    Subclasses declare the queryset and which fields are searchable; the view
+    handles the `?q=`, `?page=` and `?page_size=` contract the client runtime
+    expects:
+
+        {"results": [{"id": ..., "text": ..., "subtext": ...}],
+         "has_more": bool, "page": int}
+
+    Access control lives entirely in `get_queryset()` — the endpoint is only as
+    scoped as the queryset it returns, so subclasses must apply the same
+    filtering the corresponding form field uses.
+    """
+
+    search_fields: tuple[str, ...] = ()
+    ordering: tuple[str, ...] = ()
+    page_size = 10
+    max_page_size = 50
+
+    def get_queryset(self) -> QuerySet:
+        raise NotImplementedError
+
+    def serialize(self, obj) -> dict:
+        """Map a model instance to an option dict."""
+        return {"id": str(obj.pk), "text": str(obj)}
+
+    def get_ordering(self) -> tuple[str, ...]:
+        """Ordering must be total, or offset pages repeat and skip rows."""
+        ordering = tuple(self.ordering)
+        return ordering + ("pk",) if "pk" not in ordering else ordering
+
+    def _resolve_page_size(self, raw: str | None) -> int:
+        try:
+            requested = int(raw) if raw else self.page_size
+        except (TypeError, ValueError):
+            requested = self.page_size
+        return max(1, min(requested, self.max_page_size))
+
+    def filter_queryset(self, queryset: QuerySet, query: str) -> QuerySet:
+        if not query or not self.search_fields:
+            return queryset
+
+        condition = Q()
+        for field in self.search_fields:
+            condition |= Q(**{f"{field}__icontains": query})
+        return queryset.filter(condition)
+
+    def get(self, request, *args, **kwargs):
+        query = (request.GET.get("q") or "").strip()
+        page_size = self._resolve_page_size(request.GET.get("page_size"))
+        try:
+            page = max(1, int(request.GET.get("page") or 1))
+        except (TypeError, ValueError):
+            page = 1
+
+        queryset = self.filter_queryset(self.get_queryset(), query)
+        queryset = queryset.order_by(*self.get_ordering())
+
+        offset = (page - 1) * page_size
+        # One extra row tells us whether another page exists without a COUNT.
+        rows = list(queryset[offset : offset + page_size + 1])
+
+        return JsonResponse(
+            {
+                "results": [self.serialize(obj) for obj in rows[:page_size]],
+                "has_more": len(rows) > page_size,
+                "page": page,
+            }
+        )

--- a/utils/widgets.py
+++ b/utils/widgets.py
@@ -1,4 +1,7 @@
 from django import forms
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 from phonenumber_field.formfields import PhoneNumberField
 
 
@@ -78,6 +81,129 @@ class BaseSelectFormWidget(forms.Select):
             kwargs["attrs"]["placeholder"] = placeholder
 
         super().__init__(*args, **kwargs)
+
+
+class ComboboxSelectWidget(forms.Select):
+    """Searchable select backed by `ui/combobox.html`.
+
+    Two modes, matching the component:
+
+    * remote (`url_name` given) — `optgroups()` is neutered so **no** option is
+      ever serialized into the page. The browser fetches pages of 10 from the
+      endpoint instead, which keeps the rendered payload constant no matter how
+      large the queryset grows. `ModelChoiceField.to_python()` still validates
+      the submitted id against the field's queryset, so access scoping is
+      unchanged — only rendering is decoupled.
+    * static (no `url_name`) — the field's own choices are embedded as JSON and
+      filtered client-side. `descriptions` adds a second line per option and
+      `groups` buckets them under headings.
+
+    The widget renders through `render_to_string` rather than Django's form
+    renderer because this project keeps templates in a project-level `DIRS`
+    entry, which the default `DjangoTemplates` form renderer does not search.
+    """
+
+    template_name = "ui/combobox_widget.html"
+
+    def __init__(
+        self,
+        *args,
+        url_name=None,
+        placeholder="Selecione",
+        search_placeholder="Buscar…",
+        empty_text="Nenhum resultado",
+        descriptions=None,
+        groups=None,
+        page_size=10,
+        size="sm",
+        surface=None,
+        **kwargs,
+    ):
+        self.url_name = url_name
+        self.placeholder = placeholder
+        self.search_placeholder = search_placeholder
+        self.empty_text = empty_text
+        self.descriptions = descriptions or {}
+        self.groups = groups or {}
+        self.page_size = page_size
+        self.size = size
+        self.surface = surface
+        super().__init__(*args, **kwargs)
+
+    @property
+    def is_remote(self) -> bool:
+        return bool(self.url_name)
+
+    def id_for_label(self, id_):
+        # The focusable control is the trigger button, not the wrapper div, so
+        # `<label for="{{ field.id_for_label }}">` points at something usable.
+        return f"{id_}-trigger" if id_ else id_
+
+    def optgroups(self, name, value, attrs=None):
+        # Remote mode never ships the option list; static mode ships it as JSON
+        # in `combobox.options` instead of as <option> elements.
+        return []
+
+    def _static_options(self) -> list[dict]:
+        options = []
+        for choice_value, choice_label in self.choices:
+            if choice_value in ("", None):
+                # The blank choice becomes the trigger placeholder.
+                continue
+            option = {"id": str(choice_value), "text": str(choice_label)}
+            description = self.descriptions.get(choice_value)
+            if description:
+                option["subtext"] = str(description)
+            group = self.groups.get(choice_value)
+            if group:
+                option["group"] = str(group)
+            options.append(option)
+        return options
+
+    def _selected_text(self, value) -> str:
+        if value in ("", None):
+            return ""
+        iterator = self.choices
+        queryset = getattr(iterator, "queryset", None)
+        if queryset is not None:
+            # Single targeted lookup — never evaluates the whole queryset.
+            obj = queryset.filter(pk=value).first()
+            if obj is None:
+                return ""
+            field = getattr(iterator, "field", None)
+            return str(field.label_from_instance(obj) if field else obj)
+        for choice_value, choice_label in self.choices:
+            if str(choice_value) == str(value):
+                return str(choice_label)
+        return ""
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        raw_value = value[0] if isinstance(value, list | tuple) and value else value
+        raw_value = "" if raw_value is None else str(raw_value)
+
+        context["widget"]["combobox"] = {
+            "url": reverse(self.url_name) if self.is_remote else "",
+            "options": [] if self.is_remote else self._static_options(),
+            "value": raw_value,
+            "selected_text": self._selected_text(raw_value),
+            "placeholder": self.placeholder,
+            "search_placeholder": self.search_placeholder,
+            "empty_text": self.empty_text,
+            "page_size": self.page_size,
+            "size": self.size,
+            "surface": self.surface,
+            # Set by the form template via add_error → attrs; mirrored here so
+            # the control can flag aria-invalid without a second lookup.
+            "error": bool(attrs and attrs.get("aria-invalid")),
+        }
+        return context
+
+    def render(self, name, value, attrs=None, renderer=None):
+        context = self.get_context(name, value, attrs)
+        return mark_safe(  # noqa: S308 - template output is already escaped
+            render_to_string(self.template_name, context)
+        )
 
 
 class BaseEmailFormWidget(forms.EmailInput):


### PR DESCRIPTION
**Stack 4/7** — base `refactor/widgets-drop-tailwind` (#55). This is the substantive PR of the stack.

A native `<select>` ships every option in the page and offers no search. Measured on `/reports/`:

| | Before |
|---|---|
| Bytes per `<option>` | 94 |
| Page HTML, 5 contracts | 121 KB |
| Page HTML, 1000 contracts | ~213 KB (**+76%**) |
| Options fetched per request | all of them |
| Requests paying that cost | every GET **and** every failed POST re-render |

Plus: no search, first-letter-only type-ahead, and an unusable picker on mobile.

## Two modes
- **remote** — `url` points at a `ComboboxSearchView`. Nothing loads on page render; the first page (10 by default) loads when the panel first opens, typing refetches, reaching the bottom loads the next page. **Rendered payload is constant regardless of queryset size.**
- **static** — options embedded as JSON and filtered client-side, for fixed lists that still want search or grouping.

## Pieces
| File | Role |
|---|---|
| `ui/combobox.html` | include-API component, documented props |
| `ui/_combobox_control.html` | the control, shared by both entry points |
| `ui/combobox_widget.html` | Django widget template |
| `.ui-combobox` in `_styles.html` | styles, geometry matched to `.ui-select` |
| `window.UICombobox` | runtime, auto-inits `[data-ui-combobox]` |
| `ComboboxSearchView` | paginated JSON base view |
| `ComboboxSelectWidget` | form widget |

## The detail worth reviewing closely
`ComboboxSelectWidget.optgroups()` returns `[]`, so **no option is ever serialized** — but the field keeps its queryset and `ModelChoiceField.to_python()` still validates the submitted id against it. Only *rendering* is decoupled; access scoping is untouched.

Two other non-obvious choices:
- Pagination fetches `page_size + 1` to detect a further page without a `COUNT`, and forces `pk` into the ordering — a non-total sort makes offset pages repeat and skip rows.
- The widget renders via `render_to_string`, not Django's form renderer: this project keeps templates in a project-level `DIRS` entry, which the default `DjangoTemplates` form renderer does not search. Avoids a `FORM_RENDERER` settings change.

## Verification (live, 1366×768)
- **0** `<option>` elements rendered for either field
- 5 contracts loaded across 3 pages at `page_size=2`, **no duplicates**, chain terminates
- A page that doesn't fill the list keeps pulling until it overflows or the server runs dry — a short list has nothing to scroll, so scroll events alone would stall
- Static mode: 3 optgroups, 17 options, subtexts render
- Keyboard: ArrowDown moves `aria-activedescendant`, Enter selects, panel closes, focus returns to trigger, `aria-expanded` flips, Escape closes and keeps the value
- Search folds case **and accents** client-side (`"convenio"` → `convênio`), matching the server behaviour added in the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)