### PR TITLE
feat(search): make combobox search accent-insensitive

### DIFF
--- a/accounts/migrations/0003_unaccent_extension.py
+++ b/accounts/migrations/0003_unaccent_extension.py
@@ -1,0 +1,20 @@
+from django.contrib.postgres.operations import UnaccentExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Enable the `unaccent` extension.
+
+    Powers accent-insensitive search in ComboboxSearchView: users type "saude"
+    or "convenio" and still match "Saúde" and "Convênio". Lives in `accounts`
+    because it is the foundational app — the extension is database-wide, not
+    specific to any model here.
+    """
+
+    dependencies = [
+        ("accounts", "0002_cityhall_audesp_municipality_code_and_more"),
+    ]
+
+    operations = [
+        UnaccentExtension(),
+    ]

--- a/core/settings.py
+++ b/core/settings.py
@@ -107,6 +107,10 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    # Registers the `unaccent` lookup used by ComboboxSearchView so searching
+    # "saude" matches "Saúde". Requires the unaccent extension (see the
+    # accounts.0003 migration).
+    "django.contrib.postgres",
     # Internal apps
     "accountability",
     "activity",

--- a/utils/views.py
+++ b/utils/views.py
@@ -24,9 +24,14 @@ class ComboboxSearchView(LoginRequiredMixin, View):
     """
 
     search_fields: tuple[str, ...] = ()
+    numeric_search_fields: tuple[str, ...] = ()
     ordering: tuple[str, ...] = ()
     page_size = 10
     max_page_size = 50
+    # Accent-insensitive matching, so "saude" finds "Saúde" and "convenio"
+    # finds "Convênio". Set False for numeric-only fields, where unaccent is
+    # wasted work and blocks any index on the column.
+    unaccent_search = True
 
     def get_queryset(self) -> QuerySet:
         raise NotImplementedError
@@ -48,11 +53,16 @@ class ComboboxSearchView(LoginRequiredMixin, View):
         return max(1, min(requested, self.max_page_size))
 
     def filter_queryset(self, queryset: QuerySet, query: str) -> QuerySet:
-        if not query or not self.search_fields:
+        if not query or not (self.search_fields or self.numeric_search_fields):
             return queryset
 
         condition = Q()
+        lookup = "unaccent__icontains" if self.unaccent_search else "icontains"
         for field in self.search_fields:
+            condition |= Q(**{f"{field}__{lookup}": query})
+        # unaccent() is a text function — casting a numeric column through it
+        # errors out, so codes and ids match with a plain icontains.
+        for field in self.numeric_search_fields:
             condition |= Q(**{f"{field}__icontains": query})
         return queryset.filter(condition)
 


### PR DESCRIPTION
**Stack 5/7** — base `feat/ui-combobox` (#56).

⚠️ **This PR changes global settings and adds a migration.** Split out deliberately so that decision gets its own review — the stack works without it, just accent-sensitively.

`icontains` on Postgres is case-insensitive but **not** accent-insensitive:

| Query | Before | After |
|---|---|---|
| `saude` → "Programa Saúde Comunitária" | ❌ 0 results | ✅ |
| `convenio` → "Convênio Assistência Social" | ❌ 0 results | ✅ |
| `gestao` → "Gestão do Hospital Municipal" | ❌ 0 results | ✅ |
| `Saúde`, `1003` | ✅ | ✅ |

In a Brazilian-Portuguese product that's the common case, not an edge case — users type without accents. I found this while testing the new search, so it's a defect in the feature being added, not a pre-existing one.

## Changes
- `django.contrib.postgres` in `INSTALLED_APPS` — registers the `unaccent` lookup
- `accounts/migrations/0003_unaccent_extension.py` — `UnaccentExtension()`
- `ComboboxSearchView.unaccent_search` (default on) routes text lookups through it

`numeric_search_fields` is separate from `search_fields` because `unaccent()` is a text function: casting an integer column like `Contract.internal_code` through it errors, so numeric fields keep a plain `icontains`.

## Prerequisites confirmed
`unaccent` is available in the project's Postgres 16 image and the `sitts` role is superuser (`rolsuper = t`), so the extension applies cleanly. Migration applied against the dev database and all six query variants verified. The migration lives in `accounts` as the foundational app — the extension is database-wide, not tied to a model there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)