### PR TITLE
feat(api): contract and interested-user option endpoints

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,6 +6,7 @@ from accounts.views import (
     FolderManagerCreateView,
     FolderManagersDetailView,
     FolderManagersListView,
+    InterestedUserOptionsView,
     OrganizationAccountantCreateView,
     OrganizationAccountantsDetailView,
     OrganizationAccountantsListView,
@@ -28,6 +29,11 @@ from accounts.views import (
 
 urlpatterns = [
     # API Endpoints
+    path(
+        "interested-users/options/",
+        InterestedUserOptionsView.as_view(),
+        name="interested-user-options",
+    ),
     path(
         "get-committee-members/",
         get_committee_members,

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -36,6 +36,7 @@ from activity.models import ActivityLog, Notification
 from audesp.models import AudespCredential
 from utils.mixins import AdminRequiredMixin
 from utils.password import generate_random_password
+from utils.views import ComboboxSearchView
 
 logger = logging.getLogger(__name__)
 
@@ -827,3 +828,34 @@ def get_committee_members(request):
 
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500)
+
+
+class InterestedUserOptionsView(ComboboxSearchView):
+    """Option source for "responsible user" comboboxes.
+
+    Restricted to users who are already an interested part on a contract in one
+    of the requester's areas — the same scope the report responsible field has
+    always used.
+    """
+
+    search_fields = ("first_name", "last_name", "email")
+    ordering = ("first_name", "last_name")
+
+    def get_queryset(self) -> QuerySet[Any]:
+        from contracts.models import ContractInterestedPart
+
+        interested_part_users = (
+            ContractInterestedPart.objects.filter(
+                contract__area__in=self.request.user.areas.all()
+            )
+            .values_list("user", flat=True)
+            .distinct()
+        )
+        return User.objects.filter(id__in=interested_part_users).distinct()
+
+    def serialize(self, obj) -> dict:
+        return {
+            "id": str(obj.pk),
+            "text": obj.get_full_name() or obj.email,
+            "subtext": obj.email,
+        }

--- a/contracts/urls.py
+++ b/contracts/urls.py
@@ -12,6 +12,7 @@ from contracts.views import (
     ContractExecutionActivityUpdateView,
     ContractExecutionDetailView,
     ContractsDetailView,
+    ContractOptionsView,
     ContractsListView,
     ContractTimelineView,
     ContractUpdateView,
@@ -51,6 +52,7 @@ from contracts.views import (
 
 urlpatterns = [
     path("", ContractsListView.as_view(), name="contracts-list"),
+    path("options/", ContractOptionsView.as_view(), name="contract-options"),
     path("create/", ContractCreateView.as_view(), name="contracts-create"),
     path(
         "update/<uuid:pk>/",

--- a/contracts/views.py
+++ b/contracts/views.py
@@ -72,8 +72,10 @@ from utils.mixins import (
     AdminRequiredMixin,
     CommitteeMemberCreateMixin,
     CommitteeMemberUpdateMixin,
+    UserAccessQuerysetMixin,
     UserAccessViewMixin,
 )
+from utils.views import ComboboxSearchView
 
 logger = logging.getLogger(__name__)
 
@@ -2180,3 +2182,31 @@ class CertificateReferenceUpdateView(LoginRequiredMixin, UpdateView):
         return reverse_lazy(
             "contracts:contracts-detail", kwargs={"pk": self.object.contract.id}
         )
+
+
+class ContractOptionsView(UserAccessQuerysetMixin, ComboboxSearchView):
+    """Option source for contract comboboxes.
+
+    Scoped with the same `filter_by_user_access` rules the contract form
+    fields use, so the endpoint never widens what a user can already pick.
+    """
+
+    search_fields = ("name", "objective", "code")
+    numeric_search_fields = ("internal_code",)
+    ordering = ("-internal_code",)
+
+    def get_queryset(self) -> QuerySet[Any]:
+        return (
+            self.filter_by_user_access(Contract.objects.all(), self.request.user)
+            .select_related("area")
+            .distinct()
+        )
+
+    def serialize(self, obj) -> dict:
+        # Must match ContractChoiceField.label_from_instance so the label the
+        # endpoint returns and the one rendered for a preselected value agree.
+        return {
+            "id": str(obj.pk),
+            "text": obj.name_with_code,
+            "subtext": obj.status_label,
+        }


### PR DESCRIPTION
**Stack 6/7** — base `feat/unaccent-search` (#57).

Two `ComboboxSearchView` subclasses so the combobox has something to page against.

| Endpoint | View |
|---|---|
| `GET /contracts/options/` | `ContractOptionsView` |
| `GET /accounts/interested-users/options/` | `InterestedUserOptionsView` |

## Access scoping
Both reuse the *exact* scoping their form fields already applied — `filter_by_user_access` for contracts, and for users the same "interested part on a contract in one of my areas" query the report responsible field has always used. **These endpoints cannot widen what a user could already pick** from the select they replace.

## Two details
- `ContractOptionsView.get_queryset()` adds `.distinct()`. The non-master branch of `filter_by_user_access` joins `interested_parts`, which multiplies rows per contract and would make offset pagination repeat entries. (The same missing `.distinct()` on `ReportForm.contract` is fixed in 7/7.)
- `serialize()` returns `name_with_code` to match `ContractChoiceField.label_from_instance`, so the label the endpoint sends and the one rendered server-side for an already-selected value are identical — otherwise a 3-digit code renders as `5 - X` in one place and `0005 - X` in the other.

## Verification
Both return 200 with the documented shape. Search verified across case, accents, and numeric code. `has_more` correct at `page_size=2`.

```json
{"results": [{"id": "…", "text": "1001 - Programa Saúde Comunitária 2026", "subtext": "Em Execução"}],
 "has_more": false, "page": 1}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)