### PR TITLE
fix(ui): stop the combobox search icon overlapping its placeholder

### DIFF
--- a/templates/ui/_styles.html
+++ b/templates/ui/_styles.html
@@ -463,7 +463,11 @@ geometric display sans, sentence-case voice).
     padding: 8px;
     border-bottom: 1px solid var(--color-canvas-soft);
   }
-  .ui-combobox__search {
+  /* Bumped to (0,1,1) for the same reason as `.ui-input`: Tailwind
+     preflight's `[type="text"], …` reset is (0,1,0) and loads later in the
+     cascade, so an equal-specificity selector loses its padding and
+     font-size to it. */
+  input.ui-combobox__search {
     width: 100%;
     min-height: 36px;
     padding: 8px 12px 8px 34px;
@@ -476,8 +480,8 @@ geometric display sans, sentence-case voice).
     line-height: 18px;
     outline: none;
   }
-  .ui-combobox__search::placeholder { color: var(--color-body); }
-  .ui-combobox__search:focus { border-color: var(--color-ink); background-color: var(--color-canvas); }
+  input.ui-combobox__search::placeholder { color: var(--color-body); }
+  input.ui-combobox__search:focus { border-color: var(--color-ink); background-color: var(--color-canvas); }
   .ui-combobox__search-icon {
     position: absolute;
     left: 18px;
@@ -935,14 +939,14 @@ geometric display sans, sentence-case voice).
   @media (max-width: 720px) { .ui-grid-2, .ui-grid-3 { grid-template-columns: 1fr; } }
 
   /* === Generic form styling — applies to any Django-rendered form field inside .ui-form === */
-  .ui-form input[type="text"]:not(.ui-input):not(.file-drop-zone__input),
+  .ui-form input[type="text"]:not(.ui-input):not(.file-drop-zone__input):not(.ui-combobox__search),
   .ui-form input[type="email"]:not(.ui-input),
   .ui-form input[type="number"]:not(.ui-input),
   .ui-form input[type="date"]:not(.ui-input),
   .ui-form input[type="url"]:not(.ui-input),
   .ui-form input[type="tel"]:not(.ui-input),
   .ui-form input[type="password"]:not(.ui-input),
-  .ui-form input[type="search"]:not(.ui-input),
+  .ui-form input[type="search"]:not(.ui-input):not(.ui-combobox__search),
   .ui-form select:not(.ui-select),
   .ui-form textarea:not(.ui-textarea) {
     width: 100%;
@@ -972,7 +976,7 @@ geometric display sans, sentence-case voice).
   /* The Django widgets in utils.widgets carry no utility classes, so their
      placeholder colour has to come from here. AA-compliant (5.6:1 on the
      canvas-soft fill) — see the note on input.ui-input::placeholder. */
-  .ui-form input:not(.ui-input):not(.file-drop-zone__input)::placeholder,
+  .ui-form input:not(.ui-input):not(.file-drop-zone__input):not(.ui-combobox__search)::placeholder,
   .ui-form textarea:not(.ui-textarea)::placeholder { color: var(--color-body); }
 
   /* File input — the only Django-rendered control the rules above do not
@@ -992,10 +996,10 @@ geometric display sans, sentence-case voice).
   }
   .ui-form input[type="file"]:not(.file-drop-zone__input):hover { background-color: var(--color-surface-pressed); }
   .ui-form input[type="file"]:not(.file-drop-zone__input):focus { outline: none; border-color: var(--color-ink); border-style: solid; }
-  .ui-form input:not(.ui-input):not(.file-drop-zone__input):hover,
+  .ui-form input:not(.ui-input):not(.file-drop-zone__input):not(.ui-combobox__search):hover,
   .ui-form select:not(.ui-select):hover,
   .ui-form textarea:not(.ui-textarea):hover { background-color: var(--color-surface-pressed); }
-  .ui-form input:not(.ui-input):not(.file-drop-zone__input):focus,
+  .ui-form input:not(.ui-input):not(.file-drop-zone__input):not(.ui-combobox__search):focus,
   .ui-form select:not(.ui-select):focus,
   .ui-form textarea:not(.ui-textarea):focus {
     border-color: var(--color-ink);


### PR DESCRIPTION
**Stack 8/8** — base `fix/reports-export-page` (#59).

The search box inside the combobox panel rendered 52px tall with its placeholder starting *underneath* the magnifier icon — a 12px overlap.

## Two rules were winning, both had to be fixed
Fixing either one alone still leaves the box wrong.

**1. The generic Django-field rule outranks it.**
`.ui-form input[type="text"]:not(.ui-input):not(.file-drop-zone__input)` is **(0,3,1)** vs `.ui-combobox__search` at **(0,1,0)** — so it replaced `padding: 8px 12px 8px 34px` with `14px 16px` and `min-height: 36px` with `52px`. The search box is now opted out the same way `.ui-input` and `.file-drop-zone__input` already are, across the geometry, `:hover`, `:focus` and `::placeholder` selectors.

**2. Tailwind preflight wins on source order.**
`[type="text"], …` is **(0,1,0)** — *equal* specificity — and the CDN injects its stylesheet after ours, so it set `padding: 8px 12px` and `font-size: 1rem`. Bumped the three combobox search selectors to `input.ui-combobox__search` (0,1,1). That is the same trick already used and documented in this file for `.ui-input`:

> `/* Note: selectors are bumped to (0,1,1) so they beat Tailwind preflight's [type="text"], … reset, which is (0,1,0) and loads later in the cascade. */`

## Measured, in both `.ui-form` and `.ui-form--compact`

| | Before | After |
|---|---|---|
| `padding-left` | 16px | **34px** |
| `min-height` | 52px | **36px** |
| `font-size` | 16px | **14px** |
| box height | 52px | **36px** |
| icon span | 323–337px | 19–33px |
| text starts | 329px (under the icon) | **43px** |
| icon → text gap | **−12px (overlap)** | **+10px** |

12 changed lines, all in `ui/_styles.html`. Nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)