### PR TITLE
refactor: emit ui-input from form widgets instead of hardcoded Tailwind

### DIFF
--- a/accountability/forms.py
+++ b/accountability/forms.py
@@ -41,6 +41,7 @@ from contracts.models import ContractItem
 from utils.fields import DecimalMaskedField
 from utils.formats import format_into_brazilian_currency
 from utils.widgets import (
+    INPUT_CLASS,
     BaseCharFieldFormWidget,
     BaseDateFormWidget,
     BaseFileFormWidget,
@@ -298,11 +299,7 @@ class FavoredForm(forms.ModelForm):
 
 class ImportXLSXAccountabilityForm(forms.Form):
     xlsx_file = forms.FileField(
-        widget=forms.ClearableFileInput(
-            attrs={
-                "class": "block w-full text-sm text-black border rounded-lg cursor-pointer focus:outline-none bg-gray-300 border-gray-600 placeholder-gray-400"
-            }
-        )
+        widget=forms.ClearableFileInput(attrs={"class": INPUT_CLASS})
     )
 
     def clean_xlsx(self):
@@ -337,11 +334,9 @@ class CustomTransactionMultipleChoiceField(forms.ModelMultipleChoiceField):
 class ReconcileExpenseForm(forms.Form):
     transactions = CustomTransactionMultipleChoiceField(
         queryset=Transaction.objects.none(),
-        widget=CustomCheckboxSelectMultiple(
-            input_attrs={
-                "class": "w-4 h-4 text-blue-600 rounded-sm focus:ring-blue-600 ring-offset-gray-800 focus:ring-2 bg-gray-400 border-gray-500"
-            }
-        ),
+        # No class: both reconcile templates size these and set `accent-color`
+        # via `#id_transactions input[type="checkbox"]`.
+        widget=CustomCheckboxSelectMultiple(),
         required=True,
     )
 
@@ -400,11 +395,9 @@ class ReconcileExpenseForm(forms.Form):
 class ReconcileRevenueForm(forms.Form):
     transactions = CustomTransactionMultipleChoiceField(
         queryset=Transaction.objects.none(),
-        widget=CustomCheckboxSelectMultiple(
-            input_attrs={
-                "class": "w-4 h-4 text-blue-600 rounded-sm focus:ring-blue-600 ring-offset-gray-800 focus:ring-2 bg-gray-400 border-gray-500"
-            }
-        ),
+        # No class: both reconcile templates size these and set `accent-color`
+        # via `#id_transactions input[type="checkbox"]`.
+        widget=CustomCheckboxSelectMultiple(),
         required=True,
     )
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -3,6 +3,9 @@ from django import forms
 from accounts.models import Area, OrganizationDocument, User
 from audesp.forms import AudespCredentialAdminForm
 from utils.widgets import (
+    INPUT_CLASS,
+    SELECT_CLASS,
+    TEXTAREA_CLASS,
     BaseCharFieldFormWidget,
     BaseEmailFormWidget,
     CustomCNPJWidget,
@@ -186,42 +189,28 @@ class OrganizationDocumentForm(forms.ModelForm):
         model = OrganizationDocument
         fields = ["document_type", "title", "description", "file", "is_public"]
 
-        base_input_class = (
-            "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg "
-            "focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
-        )
-
         widgets = {
-            "document_type": forms.Select(attrs={"class": base_input_class}),
+            "document_type": forms.Select(attrs={"class": SELECT_CLASS}),
             "title": forms.TextInput(
                 attrs={
-                    "class": base_input_class,
+                    "class": INPUT_CLASS,
                     "placeholder": "Digite o título do documento",
                 }
             ),
             "description": forms.Textarea(
                 attrs={
-                    "class": base_input_class,
-                    "rows": "4",
+                    "class": TEXTAREA_CLASS,
+                    # 3 rows, not 4: `ui-input`'s 16px/24px type is taller per
+                    # row than the old 14px/20px, and 4 rows tipped this page
+                    # into scrolling at 1366x768.
+                    "rows": "3",
                     "placeholder": "Digite a descrição do documento",
                 }
             ),
-            "file": forms.FileInput(
-                attrs={
-                    "class": (
-                        "block w-full text-sm text-gray-900 border border-gray-300 "
-                        "rounded-lg cursor-pointer bg-gray-50 focus:outline-none"
-                    )
-                }
-            ),
-            "is_public": forms.CheckboxInput(
-                attrs={
-                    "class": (
-                        "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded "
-                        "focus:ring-blue-500 focus:ring-2"
-                    )
-                }
-            ),
+            "file": forms.FileInput(attrs={"class": INPUT_CLASS}),
+            # No class: `.ui-form input[type="checkbox"]` sizes it and sets
+            # `accent-color`, and a bare checkbox renders natively elsewhere.
+            "is_public": forms.CheckboxInput(),
         }
 
     def __init__(self, *args, **kwargs):

--- a/bank/forms.py
+++ b/bank/forms.py
@@ -4,6 +4,7 @@ from bank.models import BankAccount, BankStatement, Transaction
 from utils.fields import DecimalMaskedField
 from utils.regex import only_digits
 from utils.widgets import (
+    INPUT_CLASS,
     BaseCharFieldFormWidget,
     BaseNumberFormWidget,
     BaseSelectFormWidget,
@@ -47,11 +48,7 @@ class BankAccountForm(forms.ModelForm):
 
 class UpdateOFXForm(forms.Form):
     ofx_file = forms.FileField(
-        widget=forms.ClearableFileInput(
-            attrs={
-                "class": "block w-full text-sm text-black border rounded-lg cursor-pointer focus:outline-none bg-gray-300 border-gray-600 placeholder-gray-400"
-            }
-        )
+        widget=forms.ClearableFileInput(attrs={"class": INPUT_CLASS})
     )
 
     def clean_ofx_file(self):

--- a/templates/commons/nature-select.html
+++ b/templates/commons/nature-select.html
@@ -1,7 +1,7 @@
 <select
     id="{{ id|default_if_none:'id_nature' }}"
     name="{{ name|default_if_none:'nature' }}"
-    class="ui-select"
+    class="ui-input ui-select"
     required
 >
     <option value="" {% if not selected_value %}selected{% endif %}>----</option>

--- a/templates/reports/export.html
+++ b/templates/reports/export.html
@@ -183,7 +183,13 @@
   }
   .reports-period .ui-field__label { margin: 0; }
 
-  /* Compact form override — applies on top of the global `.ui-form` rules. */
+  /* Compact form override — applies on top of the global `.ui-form` rules.
+     Covers both the `.ui-*` controls emitted by `utils/widgets.py` and the
+     bare fields the generic `.ui-form` fallbacks style. The `.ui-input`
+     selectors are element-qualified so they reach (0,2,1) and outrank
+     `input.ui-input` / `select.ui-input` in `templates/ui/_styles.html`. */
+  .ui-form--compact input.ui-input,
+  .ui-form--compact select.ui-input,
   .ui-form--compact select:not(.ui-select),
   .ui-form--compact input[type="text"]:not(.ui-input),
   .ui-form--compact input[type="number"]:not(.ui-input),
@@ -194,6 +200,7 @@
     font-size: 14px;
     line-height: 18px;
   }
+  .ui-form--compact select.ui-input,
   .ui-form--compact select:not(.ui-select) {
     padding-right: 32px;
     background-position: right 10px center;

--- a/utils/fields.py
+++ b/utils/fields.py
@@ -19,6 +19,12 @@ class LowerCaseEmailField(models.EmailField):
 
 
 class DecimalMaskedField(forms.DecimalField):
+    # Money fields sit next to `utils.widgets` controls in every form that uses
+    # them, so they need the same `ui-input` geometry. Set only the class here —
+    # `required` comes from the field, and hardcoding it in attrs would mark the
+    # `required=False` call sites as required in the rendered HTML.
+    widget = forms.NumberInput(attrs={"class": "ui-input"})
+
     def to_python(self, value):
         if isinstance(value, str):
             value = re.sub(r"\.", "", value).replace(",", ".")

--- a/utils/widgets.py
+++ b/utils/widgets.py
@@ -1,6 +1,21 @@
 from django import forms
 from phonenumber_field.formfields import PhoneNumberField
 
+# Control classes are defined in `templates/ui/_styles.html`. Emit those instead
+# of Tailwind utilities: the `.ui-*` rules are element-scoped
+# (`input.ui-input`, `select.ui-input`, …), so they carry the ink/canvas palette
+# from DESIGN.md with or without a surrounding `.ui-form` wrapper.
+#
+# Selects and textareas carry `ui-select`/`ui-textarea` on top of `ui-input`.
+# The generic `.ui-form` fallbacks are written as `select:not(.ui-select)` /
+# `textarea:not(.ui-textarea)` — specificity (0,2,1), which outranks
+# `select.ui-input` (0,1,1). Without the extra token those fallbacks would keep
+# winning inside a `.ui-form`. It also restores `resize: vertical`, which
+# `ui-input` alone does not set on a textarea.
+INPUT_CLASS = "ui-input"
+SELECT_CLASS = "ui-input ui-select"
+TEXTAREA_CLASS = "ui-input ui-textarea"
+
 
 class BaseCharFieldFormWidget(forms.TextInput):
     def __init__(
@@ -13,26 +28,7 @@ class BaseCharFieldFormWidget(forms.TextInput):
     ):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
+                "class": INPUT_CLASS,
                 "required": required,
             }
         )
@@ -49,26 +45,7 @@ class BaseDateFormWidget(forms.DateInput):
     def __init__(self, *args, placeholder="dd/mm/aaaa", required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
+                "class": INPUT_CLASS,
                 "required": required,
                 "placeholder": placeholder,
                 "datepicker": "",
@@ -84,26 +61,7 @@ class BaseNumberFormWidget(forms.NumberInput):
     def __init__(self, *args, placeholder=None, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
+                "class": INPUT_CLASS,
                 "required": required,
             }
         )
@@ -117,27 +75,7 @@ class BaseTextAreaFormWidget(forms.Textarea):
     def __init__(self, *args, placeholder=None, required=True, rows=3, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "placeholder-gray-400",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                        "resize-vertical",
-                    ]
-                ),
+                "class": TEXTAREA_CLASS,
                 "rows": rows,
                 "required": required,
             }
@@ -152,25 +90,7 @@ class BaseSelectFormWidget(forms.Select):
     def __init__(self, *args, placeholder=None, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block",
-                        "w-full",
-                        "px-3",
-                        "py-2.5",
-                        "text-sm",
-                        "text-gray-900",
-                        "bg-gray-200",
-                        "border",
-                        "border-gray-300",
-                        "rounded-lg",
-                        "focus:ring-2",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                        "transition-colors",
-                        "duration-200",
-                    ]
-                ),
+                "class": SELECT_CLASS,
                 "required": required,
             }
         )
@@ -184,22 +104,7 @@ class BaseEmailFormWidget(forms.EmailInput):
     def __init__(self, *args, placeholder=None, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "border",
-                        "text-sm",
-                        "rounded-lg",
-                        "block",
-                        "w-full",
-                        "p-2.5",
-                        "bg-gray-200",
-                        "border-gray-600",
-                        "placeholder-gray-600",
-                        "text-black",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                    ]
-                ),
+                "class": INPUT_CLASS,
                 "required": required,
             }
         )
@@ -213,13 +118,7 @@ class BaseFileFormWidget(forms.FileInput):
     def __init__(self, *args, required=True, **kwargs):
         kwargs.setdefault("attrs", {}).update(
             {
-                "class": " ".join(
-                    [
-                        "block w-full text-sm text-gray-900 border",
-                        "border-gray-600 rounded-lg cursor-pointer",
-                        "bg-gray-300 focus:outline-none",
-                    ]
-                ),
+                "class": INPUT_CLASS,
                 "required": required,
             }
         )
@@ -248,22 +147,7 @@ class CustomPhoneNumberField(PhoneNumberField):
             "widget",
             forms.TextInput(
                 attrs={
-                    "class": " ".join(
-                        [
-                            "w-full",
-                            "p-2.5",
-                            "block",
-                            "text-sm",
-                            "border",
-                            "rounded-lg",
-                            "placeholder-gray-600",
-                            "bg-gray-300",
-                            "border-gray-600",
-                            "text-black",
-                            "focus:ring-blue-500",
-                            "focus:border-blue-500",
-                        ]
-                    ),
+                    "class": INPUT_CLASS,
                     "placeholder": "(00) 00000-0000",
                     "data-mask": "(00) 00000-0000",
                     "type": "tel",
@@ -279,22 +163,7 @@ class CustomCPFWidget(forms.TextInput):
         kwargs.setdefault(
             "attrs",
             {
-                "class": " ".join(
-                    [
-                        "w-full",
-                        "p-2.5",
-                        "block",
-                        "text-sm",
-                        "border",
-                        "rounded-lg",
-                        "placeholder-gray-600",
-                        "bg-gray-300",
-                        "border-gray-600",
-                        "text-black",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                    ]
-                ),
+                "class": INPUT_CLASS,
                 "placeholder": "000.000.000-00",
                 "data-mask": "000.000.000-00",
                 "type": "text",
@@ -309,22 +178,7 @@ class CustomCNPJWidget(forms.TextInput):
         kwargs.setdefault(
             "attrs",
             {
-                "class": " ".join(
-                    [
-                        "w-full",
-                        "p-2.5",
-                        "block",
-                        "text-sm",
-                        "border",
-                        "rounded-lg",
-                        "placeholder-gray-600",
-                        "bg-gray-300",
-                        "border-gray-600",
-                        "text-black",
-                        "focus:ring-blue-500",
-                        "focus:border-blue-500",
-                    ]
-                ),
+                "class": INPUT_CLASS,
                 "placeholder": "00.000.000/0000-00",
                 "data-mask": "00.000.000/0000-00",
                 "type": "text",


### PR DESCRIPTION
## What

Every `Base*FormWidget` in `utils/widgets.py` hardcoded Tailwind utilities — `bg-gray-200 border-gray-300 text-gray-900 placeholder-gray-400 focus:ring-blue-500 focus:border-blue-500`. They now emit the design-system classes from `templates/ui/_styles.html` via three shared constants:

```python
INPUT_CLASS    = "ui-input"
SELECT_CLASS   = "ui-input ui-select"
TEXTAREA_CLASS = "ui-input ui-textarea"
```

## Why

Those Tailwind classes were already **dead** — the rules in `templates/ui/_styles.html` override all of them, so controls render with the ink/canvas palette today. But they were a live regression risk: any specificity shift brings the blue focus ring back, which violates the ink/canvas rule in `DESIGN.md`.

The `.ui-*` selectors are element-scoped (`input.ui-input`, `select.ui-input`), so they apply with or without a surrounding `.ui-form` wrapper — strictly more robust than what was there.

## Reviewer notes

**Why selects and textareas carry two tokens.** The generic fallbacks are written as `.ui-form select:not(.ui-select)` / `.ui-form textarea:not(.ui-textarea)` — specificity (0,2,1) — which **outranks** `select.ui-input` (0,1,1). With `ui-input` alone the generic fallback would keep winning inside a `.ui-form`. The extra token also restores `resize: vertical` on textareas (which `ui-input` doesn't set) and gives selects `text-overflow: ellipsis`. The reasoning is captured in a comment at the top of `utils/widgets.py`.

**Four consequential fixes beyond the swap:**

- `templates/reports/export.html` — its `.ui-form--compact` overrides were keyed on `:not(.ui-input)` / `:not(.ui-select)`. Left alone, `/reports` selects would have jumped 38px → 58px on a page deliberately built dense. Selectors are now element-qualified to reach (0,2,1).
- `templates/commons/nature-select.html` and `utils/fields.py` — a bare `ui-select` and `DecimalMaskedField`'s unclassed `NumberInput` sat at 52px among the now-58px widgets *in the same forms*. `DecimalMaskedField` sets only the class, **not** `required` — hardcoding that in attrs would mark the `required=False` call sites as required in the rendered HTML.
- `accounts/forms.py`, `bank/forms.py`, `accountability/forms.py` — five more inline widget definitions carried their own hardcoded Tailwind (`bg-gray-50`, `focus:ring-blue-500`) and were the last remaining sources of the blue focus ring. Leaving them would have meant a second pass over the same verification surface. `grep` for Tailwind form classes across all `*.py` now returns nothing.
- `OrganizationDocumentForm`'s description drops to `rows="3"` — at 4 rows the taller `ui-input` type (16px/24px vs 14px/20px) tipped `/accounts/documents/add/` into scrolling at 1366×768.

**Scope note.** 31 templates contain a `<form>` without a `.ui-form` wrapper, which is what made this need its own pass. Checked all of them: only 3 render Django form fields, and none use the `Base*` widgets (they use `filter-field__control` inputs and a plain `SelectMultiple`), so nothing in that set was relying on the Tailwind classes.

## Verification

Audited 27 pages at 1366×768 against a seeded instance, then re-ran the identical audit against `git checkout HEAD` of the changed files for a true before/after.

- **No control lost its styling** — zero off-palette controls (white or transparent background) on any page.
- **No page gained a scrollbar.** Horizontal overflow is 0 everywhere, before and after. `/reports/` is unchanged at 48px with selects held at 38px. Every other overflowing page already overflowed by 226–1724px, against a maximum possible delta of ~52px; the three pages baselined directly grew 28–30px.
- The 4px growth also **removed** pre-existing staggers — `/contracts/create/` previously mixed 52px widget fields with 58px hand-written `ui-input` fields; all 20 controls are now uniform.
- Textareas got *shorter* (120px → 106px), so textarea-heavy pages like `/contracts/detail/<id>/goals/create/` shrank ~76px.

`make format` and `manage.py check` pass; `makemigrations --check` reports no changes.

**Known pre-existing issue, not touched here:** four hand-written account pages (`folder-managers/create.html:52`, `folder-managers/detail.html:55`, `organization-accountants/detail.html:48`, `organization-committees/detail.html:48`) put a 52px `ui-select` next to a 58px `ui-input` in the same grid row. That predates this change and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
