### PR TITLE
fix(contracts): apply the contract detail queryset that was never used

### DIFF
--- a/contracts/views.py
+++ b/contracts/views.py
@@ -268,28 +268,28 @@ class ContractsDetailView(UserAccessViewMixin, LoginRequiredMixin, DetailView):
                 "hired_company",
                 "hired_manager",
                 "organization",
-                "inversting_account",
+                "investing_account",
                 "checking_account",
             )
             .prefetch_related(
                 "accountabilities",
                 "addendums",
                 "items",
-                "items__items_reviews",
-                "items__items_reviews__reviewer",
                 "interested_parts",
                 "interested_parts__user",
                 "goals",
-                "goals__goals_reviews",
-                "goals__goals_reviews__reviewer",
                 "goals__steps",
             )
         )
 
-    def get_object(self, queryset=None):
-        base_queryset = self.model.objects.all()
-        filtered_queryset = self.get_user_filtered_queryset(base_queryset)
-        return filtered_queryset.get(id=self.kwargs["pk"])
+    def get_object(self, queryset=None) -> Contract:
+        # Must go through get_queryset(): building the queryset from
+        # self.model.objects.all() here meant none of the joins above were ever
+        # applied, so the page ran a full set of N+1 queries.
+        return get_object_or_404(
+            self.get_user_filtered_queryset(self.get_queryset()),
+            id=self.kwargs["pk"],
+        )
 
     def get_context_data(self, **kwargs) -> dict:
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
**Stack: 1/5** — base `main`

`ContractsDetailView.get_object()` built its queryset from `self.model.objects.all()`, bypassing `get_queryset()` entirely. Every `select_related`/`prefetch_related` declared there was dead code, so the detail page ran a full set of N+1 queries on each visit.

Because that block never executed, three invalid lookups in it were never caught:

- `inversting_account` is a typo; the field is `investing_account`. An invalid `select_related` raises `FieldError`, which is itself proof the code never ran.
- `items__items_reviews` and `goals__goals_reviews` do not exist. The related names are `item_reviews` and `goal_reviews`.

The review relations are **dropped rather than renamed**: `ContractItem.last_reviews` and `ContractGoal.last_reviews` re-order and slice the relation, so a prefetch cache cannot serve them and prefetching would only add a wasted query.

`get_object()` now goes through `get_queryset()` and uses `get_object_or_404`, so a contract the user cannot reach returns 404 instead of an unhandled `DoesNotExist` 500.

## Verification

- All 14 remaining join paths resolve against `Contract._meta` (checked programmatically).
- `manage.py check` clean.

This stands alone — it fixes the existing page and does not depend on the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)