### PR TITLE
chore(ui): make mask and form-loader init survive DOM updates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -888,28 +888,29 @@
 </script>
 
 <script>
-  document.addEventListener("DOMContentLoaded", function() {
-    // Phone mask
-    document.querySelectorAll('input[data-mask="(00) 00000-0000"]').forEach(function(input) {
-      IMask(input, {
-        mask: '(00) 00000-0000',
-        lazy: false,
-        placeholderChar: '_',
-        prepare: function(s) { return s.replace(/[^0-9]/g, ''); }
+  // Input masks. Exposed on window so pages that swap content in without a
+  // page load (e.g. the contract section nav) can mask the new fields too.
+  // Idempotent: an input is only ever masked once.
+  window.SITTS = window.SITTS || {};
+  window.SITTS.initMasks = function(root) {
+    var scope = root || document;
+    ['(00) 00000-0000', '000.000.000-00'].forEach(function(mask) {
+      scope.querySelectorAll('input[data-mask="' + mask + '"]').forEach(function(input) {
+        if (input.dataset.maskReady === 'true') return;
+        input.dataset.maskReady = 'true';
+        IMask(input, {
+          mask: mask,
+          lazy: false,
+          placeholderChar: '_',
+          prepare: function(s) { return s.replace(/[^0-9]/g, ''); }
+        });
+        input.addEventListener('invalid', function(e) { e.preventDefault(); });
       });
-      input.addEventListener('invalid', function(e) { e.preventDefault(); });
     });
+  };
 
-    // CPF mask
-    document.querySelectorAll('input[data-mask="000.000.000-00"]').forEach(function(input) {
-      IMask(input, {
-        mask: '000.000.000-00',
-        lazy: false,
-        placeholderChar: '_',
-        prepare: function(s) { return s.replace(/[^0-9]/g, ''); }
-      });
-      input.addEventListener('invalid', function(e) { e.preventDefault(); });
-    });
+  document.addEventListener("DOMContentLoaded", function() {
+    window.SITTS.initMasks(document);
 
     // Notifications fetch + render with the new card chrome
     var notificationsLoaded = false;
@@ -984,19 +985,20 @@
     }, 500);
   }
 
-  document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll("form").forEach(function(form) {
-      form.addEventListener("submit", function() {
-        var loader = document.getElementById("loader-overlay");
-        if (loader) loader.classList.remove("hidden");
-        if (form.getAttribute("target") === "download_iframe") {
-          pollForFileDownload();
-        } else {
-          var btn = form.querySelector('button[type="submit"]');
-          if (btn) btn.disabled = true;
-        }
-      });
-    });
+  // Delegated so it also covers forms added after load — content swapped in by
+  // the contract section nav, Flowbite modals, etc.
+  document.addEventListener("submit", function (event) {
+    var form = event.target;
+    if (!form || form.tagName !== "FORM") return;
+
+    var loader = document.getElementById("loader-overlay");
+    if (loader) loader.classList.remove("hidden");
+    if (form.getAttribute("target") === "download_iframe") {
+      pollForFileDownload();
+    } else {
+      var btn = form.querySelector('button[type="submit"]');
+      if (btn) btn.disabled = true;
+    }
   });
 
   // Datepicker pt-BR localization (unchanged behavior)


### PR DESCRIPTION
**Stack: 2/5** — base `fix/contract-detail-dead-queryset` (#64)

Both initialisers ran once on `DOMContentLoaded` and bound directly to the elements present at that moment, so anything added to the page afterwards was missed.

- The form loader overlay now binds **one delegated `submit` listener on `document`** instead of one per form, so forms rendered later (Flowbite modals, content fetched into the page) still show the overlay and disable their submit button.
- Mask setup moves into `window.SITTS.initMasks(root)`, callable again for a subtree. It is idempotent via a `data-mask-ready` flag, so re-running it cannot double-mask an input.

No behaviour change for existing pages — this is groundwork for #66, which replaces part of the DOM without a page load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)