### PR TITLE
design(contracts): calm the stacked AUDESP sections

### DIFF
--- a/templates/contracts/tabs/audesp-adjustments-tab.html
+++ b/templates/contracts/tabs/audesp-adjustments-tab.html
@@ -8,7 +8,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Ajustes de saldo</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §12 — retificação ou inclusão de repasse/pagamento de período anterior.</p>
       </div>
-      <a href="{% url 'accountability:balance-adjustment-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar ajuste</a>
+      <a href="{% url 'accountability:balance-adjustment-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar ajuste</a>
     </header>
     {% if balance_adjustments %}
       <div class="ui-table-wrap">
@@ -27,7 +27,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhum ajuste de saldo cadastrado</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhum ajuste de saldo cadastrado</p></div>
     {% endif %}
   </div>
 
@@ -37,7 +37,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Glosas</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §16 — análise de cada documento fiscal (ou de pagamento de Folha Ordinária).</p>
       </div>
-      <a href="{% url 'accountability:expense-rejection-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar glosa</a>
+      <a href="{% url 'accountability:expense-rejection-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar glosa</a>
     </header>
     {% if expense_rejections %}
       <div class="ui-table-wrap">
@@ -56,7 +56,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhuma glosa cadastrada</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhuma glosa cadastrada</p></div>
     {% endif %}
   </div>
 
@@ -66,7 +66,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Descontos</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §14.</p>
       </div>
-      <a href="{% url 'accountability:deduction-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar desconto</a>
+      <a href="{% url 'accountability:deduction-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar desconto</a>
     </header>
     {% if deductions %}
       <div class="ui-table-wrap">
@@ -85,7 +85,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhum desconto cadastrado</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhum desconto cadastrado</p></div>
     {% endif %}
   </div>
 
@@ -95,7 +95,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Devoluções</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §15.</p>
       </div>
-      <a href="{% url 'accountability:refund-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar devolução</a>
+      <a href="{% url 'accountability:refund-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar devolução</a>
     </header>
     {% if refunds %}
       <div class="ui-table-wrap">
@@ -114,7 +114,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhuma devolução cadastrada</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhuma devolução cadastrada</p></div>
     {% endif %}
   </div>
 

--- a/templates/contracts/tabs/audesp-registry-tab.html
+++ b/templates/contracts/tabs/audesp-registry-tab.html
@@ -8,7 +8,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Contratos com fornecedores</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §7 — contratos firmados com fornecedores usando recursos do ajuste.</p>
       </div>
-      <a href="{% url 'contracts:supplier-contract-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar contrato</a>
+      <a href="{% url 'contracts:supplier-contract-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar contrato</a>
     </header>
     {% if supplier_contracts %}
       <div class="ui-table-wrap">
@@ -28,7 +28,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhum contrato com fornecedor cadastrado</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhum contrato com fornecedor cadastrado</p></div>
     {% endif %}
   </div>
 
@@ -38,7 +38,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Bens</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §6 — um registro por evento (aquisição, cessão ou baixa/devolução).</p>
       </div>
-      <a href="{% url 'contracts:asset-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar bem</a>
+      <a href="{% url 'contracts:asset-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar bem</a>
     </header>
     {% if assets %}
       <div class="ui-table-wrap">
@@ -58,7 +58,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhum bem cadastrado</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhum bem cadastrado</p></div>
     {% endif %}
   </div>
 
@@ -68,7 +68,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Referências de certidões</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §20/§21 — identificadores de certidões já emitidas no Sistema Audesp Fase V.</p>
       </div>
-      <a href="{% url 'contracts:certificate-reference-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar referência</a>
+      <a href="{% url 'contracts:certificate-reference-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar referência</a>
     </header>
     {% if certificate_references %}
       <div class="ui-table-wrap">
@@ -86,7 +86,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhuma referência de certidão cadastrada</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhuma referência de certidão cadastrada</p></div>
     {% endif %}
   </div>
 

--- a/templates/contracts/tabs/audesp-transfers-tab.html
+++ b/templates/contracts/tabs/audesp-transfers-tab.html
@@ -8,7 +8,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Empenhos</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §17.</p>
       </div>
-      <a href="{% url 'accountability:budget-commitment-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar empenho</a>
+      <a href="{% url 'accountability:budget-commitment-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar empenho</a>
     </header>
     {% if budget_commitments %}
       <div class="ui-table-wrap">
@@ -27,7 +27,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhum empenho cadastrado</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhum empenho cadastrado</p></div>
     {% endif %}
   </div>
 
@@ -37,7 +37,7 @@
         <h2 class="ui-display-sm" style="margin:0;">Repasses</h2>
         <p class="ui-body-sm ui-text-muted" style="margin:0;">Manual AUDESP §18 — repasse efetivo vinculado a um empenho.</p>
       </div>
-      <a href="{% url 'accountability:fund-transfer-create' contract.id %}" class="ui-btn ui-btn--primary ui-btn--sm">Adicionar repasse</a>
+      <a href="{% url 'accountability:fund-transfer-create' contract.id %}" class="ui-btn ui-btn--secondary ui-btn--sm">Adicionar repasse</a>
     </header>
     {% if fund_transfers %}
       <div class="ui-table-wrap">
@@ -56,7 +56,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty"><p class="ui-display-sm">Nenhum repasse cadastrado</p></div>
+      <div class="ui-empty ui-empty--compact"><p class="ui-display-sm">Nenhum repasse cadastrado</p></div>
     {% endif %}
   </div>
 

--- a/templates/contracts/tabs/documents-tab.html
+++ b/templates/contracts/tabs/documents-tab.html
@@ -59,7 +59,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty">
+      <div class="ui-empty ui-empty--compact">
         <div class="ui-empty__icon" aria-hidden="true">
           <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
@@ -128,7 +128,7 @@
         </table>
       </div>
     {% else %}
-      <div class="ui-empty">
+      <div class="ui-empty ui-empty--compact">
         <div class="ui-empty__icon" aria-hidden="true">
           <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>

--- a/templates/ui/_styles.html
+++ b/templates/ui/_styles.html
@@ -854,6 +854,23 @@ geometric display sans, sentence-case voice).
     background-color: var(--color-canvas);
     color: var(--color-body);
   }
+  /* For pages that stack several subsections, each with its own empty state.
+     At full size four of these are ~760px of near-identical grey, which buries
+     the headings that tell them apart. */
+  .ui-empty--compact {
+    padding: 14px 16px;
+    flex-direction: row;
+    align-items: center;
+    text-align: left;
+    gap: 8px;
+  }
+  .ui-empty--compact .ui-empty__icon { display: none; }
+  .ui-empty--compact .ui-display-sm {
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 500;
+    color: var(--color-body);
+  }
 
   /* === Toolbar / filter row === */
   .ui-toolbar {


### PR DESCRIPTION
**Stack: 5/5** — base `feat/contract-section-no-reload` (#67)

Two problems on the sections that hold several subsections at once.

**Empty states are ~190px each** (48px padding plus a 48px icon). On Ajustes e glosas that is four of them — **~760px of near-identical grey**, taller than the viewport, burying the headings that tell the four subsections apart. A `ui-empty--compact` modifier drops the icon and the vertical padding for this case. Single-empty-state sections keep the full treatment, where the size is doing useful work.

**Every subsection led with a primary (black) add button.** On Fornecedores, bens e certidões that put four black pills on screen counting the page's own "Editar contrato". The subsection actions are co-equal, so none is the page's primary action: they become secondary, leaving one accent per screen as `DESIGN.md` asks. Prestações anuais has a single action and keeps it primary.

## Verification

Programmatic WCAG sweep across all 14 sections, computing the effective background per text node:

- **Zero contrast failures**, all 14 sections.
- Nav panel: zero failures.
- Zero geometry failures — no vertical or horizontal document scroll on any section.
- Ajustes e glosas now fits all four subsections above the fold at 1366×768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)