### PR TITLE
fix(ui): align the status select with its sibling input

### DIFF
--- a/templates/accounts/folder-managers/create.html
+++ b/templates/accounts/folder-managers/create.html
@@ -49,7 +49,7 @@
         <div class="ui-field"><label for="position" class="ui-field__label">Cargo</label><input type="text" name="position" id="position" required class="ui-input"></div>
         <div class="ui-field">
           <label for="is_active" class="ui-field__label">Status</label>
-          <select name="is_active" id="is_active" required class="ui-select">
+          <select name="is_active" id="is_active" required class="ui-input ui-select">
             <option value="True" selected>Ativo</option>
             <option value="False">Inativo</option>
           </select>

--- a/templates/accounts/folder-managers/detail.html
+++ b/templates/accounts/folder-managers/detail.html
@@ -52,7 +52,7 @@
         <div class="ui-field"><label for="position" class="ui-field__label">Cargo</label><input type="text" name="position" id="position" value="{{ manager.position }}" required class="ui-input"></div>
         <div class="ui-field">
           <label for="is_active" class="ui-field__label">Status</label>
-          <select name="is_active" id="is_active" required class="ui-select">
+          <select name="is_active" id="is_active" required class="ui-input ui-select">
             <option value="True" {% if manager.is_active %}selected{% endif %}>Ativo</option>
             <option value="False" {% if not manager.is_active %}selected{% endif %}>Inativo</option>
           </select>

--- a/templates/accounts/organization-accountants/detail.html
+++ b/templates/accounts/organization-accountants/detail.html
@@ -45,7 +45,7 @@
         <div class="ui-field"><label for="position" class="ui-field__label">Cargo</label><input type="text" name="position" id="position" value="{{ accountant.position }}" required class="ui-input"></div>
         <div class="ui-field">
           <label for="is_active" class="ui-field__label">Status</label>
-          <select name="is_active" id="is_active" required class="ui-select">
+          <select name="is_active" id="is_active" required class="ui-input ui-select">
             <option value="True" {% if accountant.is_active %}selected{% endif %}>Ativo</option>
             <option value="False" {% if not accountant.is_active %}selected{% endif %}>Inativo</option>
           </select>

--- a/templates/accounts/organization-committees/detail.html
+++ b/templates/accounts/organization-committees/detail.html
@@ -45,7 +45,7 @@
         <div class="ui-field"><label for="position" class="ui-field__label">Cargo</label><input type="text" name="position" id="position" value="{{ member.position }}" required class="ui-input"></div>
         <div class="ui-field">
           <label for="is_active" class="ui-field__label">Status</label>
-          <select name="is_active" id="is_active" required class="ui-select">
+          <select name="is_active" id="is_active" required class="ui-input ui-select">
             <option value="True" {% if member.is_active %}selected{% endif %}>Ativo</option>
             <option value="False" {% if not member.is_active %}selected{% endif %}>Inativo</option>
           </select>


### PR DESCRIPTION
## What

Four account templates hand-write a `<select class="ui-select">` in the same `.ui-grid-2` row as a hand-written `<input class="ui-input">`. The two controls rendered 6px apart, which reads as misalignment.

Changed `class="ui-select"` to `class="ui-input ui-select"` on:

- [`templates/accounts/folder-managers/create.html:52`](https://github.com/ToledoVitor/city-ongs/blob/claude/loving-germain-9d5255/templates/accounts/folder-managers/create.html#L52)
- [`templates/accounts/folder-managers/detail.html:55`](https://github.com/ToledoVitor/city-ongs/blob/claude/loving-germain-9d5255/templates/accounts/folder-managers/detail.html#L55)
- [`templates/accounts/organization-accountants/detail.html:48`](https://github.com/ToledoVitor/city-ongs/blob/claude/loving-germain-9d5255/templates/accounts/organization-accountants/detail.html#L48)
- [`templates/accounts/organization-committees/detail.html:48`](https://github.com/ToledoVitor/city-ongs/blob/claude/loving-germain-9d5255/templates/accounts/organization-committees/detail.html#L48)

Four lines, one token each. No CSS or Python changed.

## Why

With the global `box-sizing: border-box` set in `templates/ui/_styles.html`:

| control | computation | rendered |
| --- | --- | --- |
| `input.ui-input` | 24px line-height + 32px padding + 2px border | **58px** |
| `.ui-select` | 20px line-height + 28px padding + 2px border = 50px, raised to its `min-height` | **52px** |

Pairing the select with `ui-input` gives it the input geometry. The element-scoped `select.ui-input` rule has specificity (0,1,1) and supplies `min-height: 56px`, `padding: 16px`, `line-height: 24px` and `text-overflow: ellipsis` — all of which outrank the matching (0,1,0) declarations on `.ui-select`, while `.ui-select` keeps contributing its 44px chevron gutter.

The `ui-select` token stays deliberately. The generic `.ui-form select:not(.ui-select)` fallback has specificity (0,2,1) and would outrank `select.ui-input`. It is not in play today — all four forms are `class="ui-stack ui-stack--xl"`, not `.ui-form` — so keeping the token is defensive against one of these forms later gaining a `.ui-form` wrapper.

This misalignment predates the widget Tailwind-removal pass.

## Verification

Ran the branch in its own container against the seeded dev database at 1366×768 and measured with `getBoundingClientRect()`. The main stack on `:8000` still served the unedited templates, which gave a clean before/after on the same page.

| page | select before | select after | Δ vs sibling input |
| --- | --- | --- | --- |
| `folder-managers/create` | 52px | **58px** | 6px → **0** |
| `folder-managers/<pk>` | 52px | **58px** | 6px → **0** |
| `organization-accountants/<pk>` | 52px | **58px** | 6px → **0** |
| `organization-committees/<pk>` | 52px | **58px** | 6px → **0** |

Identical `top` and `bottom` after, not just height. Computed style on each select is now `min-height: 56px`, `padding: 16px 44px 16px 16px`, `line-height: 24px`.

## Reviewer notes

**Two pages get 6px taller.** The two `folder-managers` pages are height-neutral — the select shares its grid row with a 58px input, so it grows into existing row height. The two `organization-*` detail pages have three fields in the grid, so `is_active` wraps onto its own row:

| page | doc height before | after | viewport |
| --- | --- | --- | --- |
| `folder-managers/create` | 1222 | 1222 | 768 |
| `folder-managers/<pk>` | 1222 | 1222 | 768 |
| `organization-accountants/<pk>` | 914 | **920** | 768 |
| `organization-committees/<pk>` | 850 | **856** | 768 |

All four already exceeded the 768px viewport before this change, so all four already violated the no-scroll rule in `CLAUDE.MD`. That overflow is pre-existing and fixing it is a separate, much larger job. No horizontal scroll at 1366px before or after (1351px content).

**No existing precedent for this pairing.** Grep for `ui-input ui-select` across `templates/` returned zero hits before this change — these four are the first uses. `templates/commons/nature-select.html:4` uses bare `ui-select`, and `BaseSelectFormWidget` in `utils/widgets.py` sets no class at all.

**Unrelated bug found while verifying, not fixed here.** `templates/accounts/organization-committees/detail.html` renders every field blank and always shows "Inativo": the template reads `member.*` but `OrganizationCommitteesDetailView` sets `context_object_name = "committee"`. Confirmed against a user with `is_active=True` and a populated `position` — `email`, `position` and `cpf` all came back `value === ""`, and the select reported `value === "False"`. The sibling views (`manager`, `accountant`) are consistent, so this one is the outlier. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)