### PR TITLE
fix(reports): stop pass-on reports failing without a contract manager

### DIFF
--- a/reports/exporters/commons/contract_info.py
+++ b/reports/exporters/commons/contract_info.py
@@ -1,0 +1,24 @@
+from utils.formats import document_mask
+
+NOT_INFORMED = "Não Informado"
+
+
+def expenditure_orderer_info(contract) -> tuple[str, str, str]:
+    """Nome, cargo e documento do ordenador de despesa do órgão público parceiro.
+
+    Nenhum dos três valores volta vazio: o fpdf2 recusa ``cell(text="")`` com
+    ``ValueError: 'text_line' must have fragments if 'text_line.text_width' is
+    None``, o que transformava contrato sem gestor em erro 500 no relatório.
+    """
+    manager = getattr(contract, "contractor_manager", None)
+
+    name = manager.name if manager and manager.name else NOT_INFORMED
+
+    document = document_mask(str(manager.cnpj)) if manager and manager.cnpj else None
+    document = document or f"CNPJ: {NOT_INFORMED}"
+
+    organization = getattr(contract, "organization", None)
+    position = getattr(organization, "position", None) if organization else None
+    position = position or NOT_INFORMED
+
+    return name, position, document

--- a/reports/exporters/pass_on_11.py
+++ b/reports/exporters/pass_on_11.py
@@ -5,6 +5,7 @@ from datetime import date
 from django.conf import settings
 from fpdf import XPos, YPos
 
+from reports.exporters.commons.contract_info import expenditure_orderer_info
 from reports.exporters.commons.exporters import BasePdf
 from utils.formats import (
     document_mask,
@@ -275,19 +276,7 @@ class PassOn11PDFExporter:
         self.pdf.ln(10)
 
     def _draw_expenditure_orderer(self):
-        manager = self.contract.contractor_manager
-
-        # 1. Obter Nome e Documento de forma segura
-        manager_name = manager.name if manager else "Não Informado"
-        manager_cnpj = document_mask(
-            str(manager.cnpj) if manager and manager.cnpj else ""
-        )
-
-        # 2. Obter o Cargo usando o objeto 'organization' e a função getattr para segurança
-        # Se organization ou position for None, retorna 'Não Informado'
-        org = getattr(self.contract, "organization", None)
-        position_value = getattr(org, "position", None) if org else None
-        cargo_text = position_value if position_value else "Não Informado"
+        manager_name, cargo_text, manager_cnpj = expenditure_orderer_info(self.contract)
 
         self.__set_font(font_size=8, bold=True)
         self.pdf.cell(

--- a/reports/exporters/pass_on_13.py
+++ b/reports/exporters/pass_on_13.py
@@ -5,6 +5,7 @@ from datetime import date
 from django.conf import settings
 from fpdf import XPos, YPos
 
+from reports.exporters.commons.contract_info import expenditure_orderer_info
 from reports.exporters.commons.exporters import BasePdf
 from utils.formats import (
     document_mask,
@@ -275,19 +276,7 @@ class PassOn13PDFExporter:
         self.pdf.ln(10)
 
     def _draw_expenditure_orderer(self):
-        manager = self.contract.contractor_manager
-
-        # 1. Obter Nome e Documento de forma segura
-        manager_name = manager.name if manager else "Não Informado"
-        manager_cnpj = document_mask(
-            str(manager.cnpj) if manager and manager.cnpj else ""
-        )
-
-        # 2. Obter o Cargo usando o objeto 'organization' e a função getattr para segurança
-        # Se organization ou position for None, retorna 'Não Informado'
-        org = getattr(self.contract, "organization", None)
-        position_value = getattr(org, "position", None) if org else None
-        cargo_text = position_value if position_value else "Não Informado"
+        manager_name, cargo_text, manager_cnpj = expenditure_orderer_info(self.contract)
 
         self.__set_font(font_size=8, bold=True)
         self.pdf.cell(

--- a/reports/exporters/pass_on_3.py
+++ b/reports/exporters/pass_on_3.py
@@ -5,6 +5,7 @@ from datetime import date
 from django.conf import settings
 from fpdf import XPos, YPos
 
+from reports.exporters.commons.contract_info import expenditure_orderer_info
 from reports.exporters.commons.exporters import BasePdf
 from utils.formats import (
     document_mask,
@@ -275,19 +276,7 @@ class PassOn3PDFExporter:
         self.pdf.ln(10)
 
     def _draw_expenditure_orderer(self):
-        manager = self.contract.contractor_manager
-
-        # 1. Obter Nome e Documento de forma segura
-        manager_name = manager.name if manager else "Não Informado"
-        manager_cnpj = document_mask(
-            str(manager.cnpj) if manager and manager.cnpj else ""
-        )
-
-        # 2. Obter o Cargo usando o objeto 'organization' e a função getattr para segurança
-        # Se organization ou position for None, retorna 'Não Informado'
-        org = getattr(self.contract, "organization", None)
-        position_value = getattr(org, "position", None) if org else None
-        cargo_text = position_value if position_value else "Não Informado"
+        manager_name, cargo_text, manager_cnpj = expenditure_orderer_info(self.contract)
 
         self.__set_font(font_size=8, bold=True)
         self.pdf.cell(

--- a/reports/exporters/pass_on_5.py
+++ b/reports/exporters/pass_on_5.py
@@ -5,6 +5,7 @@ from datetime import date
 from django.conf import settings
 from fpdf import XPos, YPos
 
+from reports.exporters.commons.contract_info import expenditure_orderer_info
 from reports.exporters.commons.exporters import BasePdf
 from utils.formats import (
     document_mask,
@@ -275,19 +276,7 @@ class PassOn5PDFExporter:
         self.pdf.ln(10)
 
     def _draw_expenditure_orderer(self):
-        manager = self.contract.contractor_manager
-
-        # 1. Obter Nome e Documento de forma segura
-        manager_name = manager.name if manager else "Não Informado"
-        manager_cnpj = document_mask(
-            str(manager.cnpj) if manager and manager.cnpj else ""
-        )
-
-        # 2. Obter o Cargo usando o objeto 'organization' e a função getattr para segurança
-        # Se organization ou position for None, retorna 'Não Informado'
-        org = getattr(self.contract, "organization", None)
-        position_value = getattr(org, "position", None) if org else None
-        cargo_text = position_value if position_value else "Não Informado"
+        manager_name, cargo_text, manager_cnpj = expenditure_orderer_info(self.contract)
 
         self.__set_font(font_size=8, bold=True)
         self.pdf.cell(

--- a/reports/exporters/pass_on_7.py
+++ b/reports/exporters/pass_on_7.py
@@ -5,6 +5,7 @@ from datetime import date
 from django.conf import settings
 from fpdf import XPos, YPos
 
+from reports.exporters.commons.contract_info import expenditure_orderer_info
 from reports.exporters.commons.exporters import BasePdf
 from utils.formats import (
     document_mask,
@@ -275,19 +276,7 @@ class PassOn7PDFExporter:
         self.pdf.ln(10)
 
     def _draw_expenditure_orderer(self):
-        manager = self.contract.contractor_manager
-
-        # 1. Obter Nome e Documento de forma segura
-        manager_name = manager.name if manager else "Não Informado"
-        manager_cnpj = document_mask(
-            str(manager.cnpj) if manager and manager.cnpj else ""
-        )
-
-        # 2. Obter o Cargo usando o objeto 'organization' e a função getattr para segurança
-        # Se organization ou position for None, retorna 'Não Informado'
-        org = getattr(self.contract, "organization", None)
-        position_value = getattr(org, "position", None) if org else None
-        cargo_text = position_value if position_value else "Não Informado"
+        manager_name, cargo_text, manager_cnpj = expenditure_orderer_info(self.contract)
 
         self.__set_font(font_size=8, bold=True)
         self.pdf.cell(

--- a/reports/exporters/pass_on_9.py
+++ b/reports/exporters/pass_on_9.py
@@ -5,6 +5,7 @@ from datetime import date
 from django.conf import settings
 from fpdf import XPos, YPos
 
+from reports.exporters.commons.contract_info import expenditure_orderer_info
 from reports.exporters.commons.exporters import BasePdf
 from utils.formats import (
     document_mask,
@@ -275,19 +276,7 @@ class PassOn9PDFExporter:
         self.pdf.ln(10)
 
     def _draw_expenditure_orderer(self):
-        manager = self.contract.contractor_manager
-
-        # 1. Obter Nome e Documento de forma segura
-        manager_name = manager.name if manager else "Não Informado"
-        manager_cnpj = document_mask(
-            str(manager.cnpj) if manager and manager.cnpj else ""
-        )
-
-        # 2. Obter o Cargo usando o objeto 'organization' e a função getattr para segurança
-        # Se organization ou position for None, retorna 'Não Informado'
-        org = getattr(self.contract, "organization", None)
-        position_value = getattr(org, "position", None) if org else None
-        cargo_text = position_value if position_value else "Não Informado"
+        manager_name, cargo_text, manager_cnpj = expenditure_orderer_info(self.contract)
 
         self.__set_font(font_size=8, bold=True)
         self.pdf.cell(


### PR DESCRIPTION
## What

Six pass-on exporters raised an unhandled `ValueError` — a 500 for the user — whenever the contract had no `contractor_manager`:

- [reports/exporters/pass_on_3.py](reports/exporters/pass_on_3.py)
- [reports/exporters/pass_on_5.py](reports/exporters/pass_on_5.py)
- [reports/exporters/pass_on_7.py](reports/exporters/pass_on_7.py)
- [reports/exporters/pass_on_9.py](reports/exporters/pass_on_9.py)
- [reports/exporters/pass_on_11.py](reports/exporters/pass_on_11.py)
- [reports/exporters/pass_on_13.py](reports/exporters/pass_on_13.py)

## Why

`_draw_expenditure_orderer` gave `manager_name` and `cargo_text` a `"Não Informado"` fallback, but the document fell back to `""` — and `document_mask` returns `None` for falsy input ([utils/formats.py:16](utils/formats.py:16)). fpdf2 rejects that:

```
ValueError: 'text_line' must have fragments if 'text_line.text_width' is None
```

The block was copy-pasted verbatim across all six files, so the same crash appeared six times.

## How

New `reports/exporters/commons/contract_info.py` holds `expenditure_orderer_info(contract)`, returning name, position and document with no empty values. Each exporter drops 13 lines of duplicated extraction for one call.

Fallback is `"CNPJ: Não Informado"`, not a bare `"Não Informado"`: the working path renders `CNPJ: **.279.736/0001-**` because `document_mask` supplies that label itself, so a bare value would be an unlabeled line sitting between `Nome:` and `Cargo:`. `Company.cnpj` is a required `CNPJField`, so the label is always CNPJ, never CPF.

## Reviewer notes

**Only the value extraction moved — the drawing calls stay inline on purpose.** `self.__set_font` is name-mangled per class (`_PassOn3PDFExporter__set_font`, `_PassOn5PDFExporter__set_font`, …). Hoisting the whole method into a shared mixin would resolve it as `_ExpenditureOrdererMixin__set_font` and raise `AttributeError`, so the tempting full-DRY refactor is not available here.

## Verification

sqlite in-memory harness with `run_seed()` per `CLAUDE.MD`, identical fixture before and after, on a contract with `contractor_manager = None`:

| | before | after |
|---|---|---|
| pass_on 3/5/7/9/11/13 | `ValueError` ×6 | valid PDF ×6 (~21 KB, `%PDF-` header) |

Rendered block on the no-manager path:

```
ORDENADOR DE DESPESA DO ÓRGÃO PÚBLICO PARCEIRO:
Nome: Não Informado
Cargo: Não Informado
CNPJ: Não Informado
Assinatura: ___________________________
```

Manager-*present* path re-run separately — all six still render and that block is unchanged (`CNPJ: **.279.736/0001-**`).

`manage.py check` clean · `makemigrations --check` reports no changes · `make format` passes.

## Out of scope — found while testing

Reaching the orderer block required populating other null FKs in the fixture, because these crash the same six exporters *earlier* with the identical unguarded-`None` pattern:

- `hired_company.city` → `_draw_notificated` ([pass_on_3.py:234](reports/exporters/pass_on_3.py:234))
- `supervision_autority.cpf` → ([pass_on_3.py:363](reports/exporters/pass_on_3.py:363))
- `accountability_autority.cpf` → same pattern

Also latent: `_draw_public_authority` ([pass_on_3.py:272](reports/exporters/pass_on_3.py:272)) passes `document_mask(...)` straight into `text=`, so it hits this same `ValueError` if `city_hall.document` is ever empty. None of these are touched here — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)