### PR TITLE
infra: rebuild GCP on a new project, split storage buckets, serve app.sitts.com.br

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ DB_HOST=db
 DB_PORT=5432
 
 STATIC_URL=/static/
+# Dois buckets: o de estáticos é público, o de mídia é privado (URLs
+# assinadas). Nunca aponte os dois para o mesmo bucket em produção — uploads
+# carregam CPF e dados financeiros. GS_BUCKET_NAME é o nome antigo, mantido
+# como fallback para ambientes ainda não migrados.
+GS_STATIC_BUCKET_NAME=
+GS_MEDIA_BUCKET_NAME=
 GS_BUCKET_NAME=
 
 WEBSITE_URL=http://localhost:8000

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -55,9 +55,12 @@ jobs:
 
       - name: Pre-deploy (migrate and collectstatic)
         run: |
-          gcloud run jobs update ${{ env.SERVICE }}-pre-deploy \
+          # `deploy`, not `update`: update requires the job to already exist, so
+          # a rebuilt project could never run this workflow once. deploy creates
+          # it on first run and updates it thereafter.
+          gcloud run jobs deploy ${{ env.SERVICE }}-pre-deploy \
           --labels ^,^application=${{ env.SERVICE }},component=pre-deploy \
-          --set-env-vars="ENV=production,GOOGLE_CLOUD_PROJECT=sitts-504501" \
+          --set-env-vars="ENV=production,GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }}" \
           --set-secrets=DJANGO_SETTINGS=django_settings:latest \
           --region=${{ env.REGION }} \
           --image=${{ env.IMAGE_NAME }} \

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -129,6 +129,7 @@ jobs:
             --service-account=${{ env.RUNTIME_SA }}
             --add-cloudsql-instances=${{ env.CLOUDSQL_INSTANCE }}
             --set-env-vars=GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }}
+            --allow-unauthenticated
 
       - name: Tag production docker image
         run: |

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -5,11 +5,13 @@ on:
 
 env:
   DOCKER_REGISTRY: southamerica-east1-docker.pkg.dev
-  DOCKER_REPO: sitts-project/cloud-run-source-deploy
+  DOCKER_REPO: sitts-504501/cloud-run-source-deploy
   REGION: southamerica-east1
   SERVICE: sitts
-  PROJECT_ID: sitts-project
+  PROJECT_ID: sitts-504501
   ENV: production
+  RUNTIME_SA: sitts-run@sitts-504501.iam.gserviceaccount.com
+  CLOUDSQL_INSTANCE: sitts-504501:southamerica-east1:sitts-db
 
 jobs:
   production:
@@ -29,8 +31,8 @@ jobs:
           export_environment_variables: true
           project_id: "${{ env.PROJECT_ID}}"
           token_format: "access_token"
-          workload_identity_provider: "projects/455340212401/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "github-deploy@sitts-project.iam.gserviceaccount.com"
+          workload_identity_provider: "projects/665645565019/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "github-deploy@sitts-504501.iam.gserviceaccount.com"
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
@@ -55,10 +57,12 @@ jobs:
         run: |
           gcloud run jobs update ${{ env.SERVICE }}-pre-deploy \
           --labels ^,^application=${{ env.SERVICE }},component=pre-deploy \
-          --set-env-vars="ENV=production,GOOGLE_CLOUD_PROJECT=sitts-project" \
+          --set-env-vars="ENV=production,GOOGLE_CLOUD_PROJECT=sitts-504501" \
           --set-secrets=DJANGO_SETTINGS=django_settings:latest \
           --region=${{ env.REGION }} \
           --image=${{ env.IMAGE_NAME }} \
+          --service-account=${{ env.RUNTIME_SA }} \
+          --set-cloudsql-instances=${{ env.CLOUDSQL_INSTANCE }} \
           --cpu=1 \
           --memory=512Mi \
           --max-retries=1 \
@@ -119,6 +123,9 @@ jobs:
             --execution-environment=gen1
             --concurrency=4
             --timeout=300
+            --service-account=${{ env.RUNTIME_SA }}
+            --add-cloudsql-instances=${{ env.CLOUDSQL_INSTANCE }}
+            --set-env-vars=GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }}
 
       - name: Tag production docker image
         run: |

--- a/core/settings.py
+++ b/core/settings.py
@@ -114,14 +114,19 @@ if not os.path.exists(os.path.join(BASE_DIR, "logs")):
 ALLOWED_HOSTS: List[str] = ["*"]
 
 CSRF_TRUSTED_ORIGINS = [
-    # Cloud Run's own URL. Keep it: it stays reachable if DNS or the domain
-    # mapping's certificate ever breaks, which makes it the way back in.
+    # Cloud Run's own URL. Keep it: it stays reachable if DNS, Firebase Hosting
+    # or the managed certificate breaks, which makes it the way back in. It is
+    # also the way around Firebase's 60s timeout for a long report export.
     "https://sitts-bdhqfqo3cq-rj.a.run.app",
-    "https://www.sitts.com.br",
-    "https://sitts.com.br",
-    # Left over from the deleted project; no longer mapped to any service.
-    "https://gestao-sitts-web.com",
+    "https://app.sitts.com.br",
+    "https://sitts-504501.web.app",
 ]
+
+# Both Cloud Run and Firebase Hosting terminate TLS and forward the original
+# scheme in this header. Without it Django treats every request as plain HTTP:
+# request.is_secure() returns False, build_absolute_uri() emits http:// links
+# into password-reset emails, and secure cookies never get set.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition
 INSTALLED_APPS = [

--- a/core/settings.py
+++ b/core/settings.py
@@ -114,7 +114,7 @@ if not os.path.exists(os.path.join(BASE_DIR, "logs")):
 ALLOWED_HOSTS: List[str] = ["*"]
 
 CSRF_TRUSTED_ORIGINS = [
-    "https://sitts-665645565019.southamerica-east1.run.app",
+    "https://sitts-bdhqfqo3cq-rj.a.run.app",
     "https://gestao-sitts-web.com",
 ]
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -114,7 +114,12 @@ if not os.path.exists(os.path.join(BASE_DIR, "logs")):
 ALLOWED_HOSTS: List[str] = ["*"]
 
 CSRF_TRUSTED_ORIGINS = [
+    # Cloud Run's own URL. Keep it: it stays reachable if DNS or the domain
+    # mapping's certificate ever breaks, which makes it the way back in.
     "https://sitts-bdhqfqo3cq-rj.a.run.app",
+    "https://www.sitts.com.br",
+    "https://sitts.com.br",
+    # Left over from the deleted project; no longer mapped to any service.
     "https://gestao-sitts-web.com",
 ]
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,5 +1,6 @@
 import io
 import os
+from datetime import timedelta
 from typing import Any, Dict, List
 
 import environ
@@ -45,7 +46,7 @@ if DEVELOPMENT:
     }
 else:
     print("reading gcloud env settings")
-    project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "sitts-project")
+    project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "sitts-504501")
     settings_name = "django_settings"
 
     # Pull secrets from Secret Manager
@@ -113,7 +114,7 @@ if not os.path.exists(os.path.join(BASE_DIR, "logs")):
 ALLOWED_HOSTS: List[str] = ["*"]
 
 CSRF_TRUSTED_ORIGINS = [
-    "https://sitts-455340212401.southamerica-east1.run.app",
+    "https://sitts-665645565019.southamerica-east1.run.app",
     "https://gestao-sitts-web.com",
 ]
 
@@ -225,24 +226,56 @@ USE_L10N = True
 USE_TZ = True
 
 
-# Static files (CSS, JavaScript, Images)
-# [START gaeflex_py_django_static_config]
-# Define static storage via django-storages[google]
+# Static files (CSS, JavaScript, Images) and user uploads.
+#
+# Two buckets on purpose. Uploaded documents — contracts, bank statements,
+# accountability attachments — carry CPF and municipal financial data;
+# stylesheets do not. Serving both from one public bucket makes every upload
+# world-readable, and `roles/storage.objectViewer` on allUsers also grants
+# storage.objects.list, so the entire media set would be enumerable by anyone
+# who found the bucket name. Keep the two apart.
 STATIC_URL = env("STATIC_URL")
+
+# Falls back to the single pre-split bucket so an environment that has not been
+# migrated yet still boots. Read with a default of its own: passing
+# `default=env("GS_BUCKET_NAME")` would evaluate eagerly and raise even when the
+# two new names are set.
+_legacy_bucket = env("GS_BUCKET_NAME", default="")
+GS_STATIC_BUCKET_NAME = env("GS_STATIC_BUCKET_NAME", default=_legacy_bucket)
+GS_MEDIA_BUCKET_NAME = env("GS_MEDIA_BUCKET_NAME", default=_legacy_bucket)
+
 STORAGES = {
+    # Private bucket. querystring_auth signs every URL, so a link works for the
+    # signature's lifetime and cannot be guessed or shared indefinitely.
+    # Templates render `{{ obj.file.url }}` directly, so this is what stands
+    # between an upload and the open internet.
+    #
+    # Signing on Cloud Run goes through the IAM signBlob API rather than a key
+    # file: the runtime service account needs roles/iam.serviceAccountTokenCreator
+    # on itself (see docs/DEPLOY.md).
     "default": {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+        "OPTIONS": {
+            "bucket_name": GS_MEDIA_BUCKET_NAME,
+            "default_acl": None,
+            "querystring_auth": True,
+            "expiration": timedelta(minutes=15),
+        },
     },
+    # Public bucket: CSS/JS/admin assets only. Unsigned so URLs stay stable and
+    # cacheable — nothing here is sensitive.
     "staticfiles": {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+        "OPTIONS": {
+            "bucket_name": GS_STATIC_BUCKET_NAME,
+            "default_acl": None,
+            "querystring_auth": False,
+        },
     },
 }
-GS_QUERYSTRING_AUTH = False
-GS_BUCKET_NAME = env("GS_BUCKET_NAME")
-GS_DEFAULT_ACL = None
-STATICFILES_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
-DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
-# [END gaeflex_py_django_static_config]
+
+# Kept for anything still reading the module-level name directly.
+GS_BUCKET_NAME = GS_MEDIA_BUCKET_NAME
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/stable/ref/settings/#default-auto-field

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -55,6 +55,25 @@ Cloud SQL has **deletion protection enabled**. To actually delete the instance y
 gcloud sql instances patch sitts-db --project=sitts-504501 --no-deletion-protection
 ```
 
+## Custom domain
+
+`www.sitts.com.br`, served through a **Cloud Run domain mapping**. It costs nothing and provisions a Google-managed certificate automatically.
+
+The alternative is a global external Application Load Balancer, which is what most Cloud Run documentation steers you toward. Its forwarding rule alone is roughly $18-25/mo before a single request — more than the entire rest of this project's infrastructure combined, for a service handling three users. Domain mapping carries a lower availability SLO and Google treats it as legacy, but at this scale that is the correct trade.
+
+Domain mappings *are* supported in `southamerica-east1`, despite the region gaps in Google's own docs. Verified by attempting one: the failure was ownership verification, not region.
+
+### Bringing up a domain
+
+1. Verify ownership in Google Search Console. `gcloud domains verify sitts.com.br` opens the right page; the TXT record it asks for goes in Hostinger's DNS. Verify the **apex**, not `www` — the apex covers every subdomain.
+2. `gcloud beta run domain-mappings create --service=sitts --domain=www.sitts.com.br --region=southamerica-east1`.
+3. Add the DNS records that command prints, at Hostinger. For a subdomain it is a single `CNAME` to `ghs.googlehosted.com.`
+4. Wait for the certificate. Usually ~15 minutes, occasionally hours. `gcloud beta run domain-mappings describe` reports status.
+
+Only `www` is mapped. The apex is handled by Hostinger's own domain forwarding to `https://www.sitts.com.br`, which avoids pinning Google's four A records at the apex and keeps one canonical host for cookies and sessions.
+
+After DNS resolves, `WEBSITE_URL` in the `django_settings` secret must move to the new domain — it builds the links in password-reset emails, so it is the one setting that silently breaks if forgotten.
+
 ## Storage: two buckets, on purpose
 
 Uploads and static assets are split, and they must stay split.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -30,6 +30,16 @@ Project `sitts-504501` (number `665645565019`), everything in `southamerica-east
 | Runtime SA | `sitts-run@…` | Cloud Run identity |
 | Deploy SA | `github-deploy@…` | assumed by GitHub Actions via WIF |
 
+### IAM the workflow actually needs
+
+`github-deploy` holds `run.admin` and `artifactregistry.writer` at project level, `iam.serviceAccountUser` on `sitts-run`, and **`artifactregistry.repoAdmin` on the repository**.
+
+That last one is not optional and fails in a way that looks like success. The final step moves the `production` and `latest` tags onto the new image, and *moving* an existing tag means deleting it first — `artifactregistry.writer` grants create but not `artifactregistry.tags.delete`. So the very first deploy into a fresh project passes (no tags exist yet) and every deploy after it fails on the last step, after the service has already been updated. Granting `repoAdmin` on the repository rather than the project keeps it scoped.
+
+`sitts-run` holds `cloudsql.client`, `logging.logWriter`, `storage.objectAdmin` on both buckets, `secretmanager.secretAccessor` on `django_settings`, and `iam.serviceAccountTokenCreator` **on itself** for signing media URLs.
+
+The Cloud Run service is `--allow-unauthenticated`: it has to be anonymously reachable or nobody can load the login page. Django's own authentication protects the content.
+
 Deliberately **absent**, because each is a fixed monthly charge that buys nothing at this traffic:
 
 - **No load balancer.** The `.run.app` URL is the entry point. A global external ALB costs ~$18-25/mo for the forwarding rule alone, before traffic; Cloud Run domain mapping is the free alternative if a custom domain is needed.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -6,13 +6,59 @@
 
 What one run does:
 
-1. Authenticates to GCP through Workload Identity Federation as `github-deploy@sitts-project.iam.gserviceaccount.com`.
+1. Authenticates to GCP through Workload Identity Federation as `github-deploy@sitts-504501.iam.gserviceaccount.com`.
 2. Builds the image and pushes it to Artifact Registry under a timestamped tag.
 3. Runs `migrate` and `collectstatic` as the `sitts-pre-deploy` Cloud Run job, reading config from the `django_settings` secret.
 4. Deploys to the `sitts` Cloud Run service with 100% traffic to the new revision.
 5. Moves the `production` and `latest` tags onto the image it just built.
 
 The Cloud Run scaling flags are pinned in the workflow rather than left to the service's stored config, so an edit in the console cannot silently reintroduce always-on billing.
+
+## What exists in GCP
+
+Project `sitts-504501` (number `665645565019`), everything in `southamerica-east1`. The previous project was deleted; this is a rebuild.
+
+| Resource | Name | Notes |
+|---|---|---|
+| Cloud SQL | `sitts-db` | POSTGRES_16, `db-f1-micro`, **zonal**, 10GB SSD, public IP, 7 daily backups |
+| Cloud Run service | `sitts` | scale-to-zero |
+| Cloud Run job | `sitts-pre-deploy` | `migrate` + `collectstatic` |
+| Artifact Registry | `cloud-run-source-deploy` | cleanup policy applied |
+| GCS | `sitts-504501-static` | **public** — CSS/JS/admin assets |
+| GCS | `sitts-504501-media` | **private** — uploads, signed URLs |
+| Secret Manager | `django_settings` | all runtime config |
+| Runtime SA | `sitts-run@…` | Cloud Run identity |
+| Deploy SA | `github-deploy@…` | assumed by GitHub Actions via WIF |
+
+Deliberately **absent**, because each is a fixed monthly charge that buys nothing at this traffic:
+
+- **No load balancer.** The `.run.app` URL is the entry point. A global external ALB costs ~$18-25/mo for the forwarding rule alone, before traffic; Cloud Run domain mapping is the free alternative if a custom domain is needed.
+- **No Serverless VPC Access connector.** Cloud SQL has a public IP with *zero* authorized networks, and Cloud Run reaches it through the built-in Cloud SQL connector (`--add-cloudsql-instances`), which is IAM-authenticated and free. Switching the instance to private IP would force a connector back in at ~$15-20/mo.
+- **No HA / regional availability.** That is an exact 2x on the Cloud SQL bill.
+- **No App Engine.** The old `app.yaml` targeted App Engine Flex, which runs always-on VMs and does not scale to zero.
+
+A billing budget of $15/mo is set on the billing account with alerts at 50%, 80% and 100%. Cloud SQL is the only meaningful line item — everything else lands under ~$1/mo combined.
+
+Cloud SQL has **deletion protection enabled**. To actually delete the instance you must clear it first:
+
+```bash
+gcloud sql instances patch sitts-db --project=sitts-504501 --no-deletion-protection
+```
+
+## Storage: two buckets, on purpose
+
+Uploads and static assets are split, and they must stay split.
+
+Templates render `{{ obj.file.url }}` directly, so whatever the storage backend returns *is* the link handed to the browser. Before the split there was one bucket with `GS_QUERYSTRING_AUTH = False`, meaning unsigned URLs — which only work if the bucket is world-readable. `roles/storage.objectViewer` on `allUsers` also grants `storage.objects.list`, so that configuration would have let anyone who learned the bucket name enumerate and download every contract, bank statement and accountability attachment in the system, on a product that also stores CPF.
+
+Now:
+
+- `sitts-504501-static` is public and unsigned. It holds CSS, JS and Django admin assets. Nothing sensitive, and unsigned URLs stay cacheable.
+- `sitts-504501-media` is private. `querystring_auth` is on, so every URL is signed and expires after 15 minutes.
+
+Signing from Cloud Run uses the IAM `signBlob` API rather than a service-account key file, which is why `sitts-run` holds `roles/iam.serviceAccountTokenCreator` **on itself**. Remove that binding and every file link in the app breaks.
+
+Note what this does *not* do: a signed URL is bearer access for its lifetime, and nothing checks that the requester belongs to the tenant that owns the file. Serving uploads through a permission-checked Django view is the real fix if the threat model tightens.
 
 ## Instance sizing
 
@@ -103,24 +149,24 @@ Deliberate, for three reasons:
 
 ### Applying it
 
-Run from a machine authenticated as an account with registry admin on `sitts-project` (the deploy service account does not have it — see above). Note that the active `gcloud` project is probably not `sitts-project`, hence the explicit `--project`.
+Run from a machine authenticated as an account with registry admin on `sitts-504501` (the deploy service account does not have it — see above). Note that the active `gcloud` project is probably not `sitts-504501`, hence the explicit `--project`.
 
 Arm it in dry-run mode first. Policies are evaluated and the matches are logged, but nothing is deleted:
 
 ```bash
-gcloud artifacts repositories set-cleanup-policies cloud-run-source-deploy --project=sitts-project --location=southamerica-east1 --policy=.github/artifact-registry-cleanup-policy.json --dry-run
+gcloud artifacts repositories set-cleanup-policies cloud-run-source-deploy --project=sitts-504501 --location=southamerica-east1 --policy=.github/artifact-registry-cleanup-policy.json --dry-run
 ```
 
 Review what it would have removed in Cloud Logging before going further. Once the matches look right, make it live:
 
 ```bash
-gcloud artifacts repositories set-cleanup-policies cloud-run-source-deploy --project=sitts-project --location=southamerica-east1 --policy=.github/artifact-registry-cleanup-policy.json --no-dry-run
+gcloud artifacts repositories set-cleanup-policies cloud-run-source-deploy --project=sitts-504501 --location=southamerica-east1 --policy=.github/artifact-registry-cleanup-policy.json --no-dry-run
 ```
 
 Confirm what the repository ended up with:
 
 ```bash
-gcloud artifacts repositories describe cloud-run-source-deploy --project=sitts-project --location=southamerica-east1
+gcloud artifacts repositories describe cloud-run-source-deploy --project=sitts-504501 --location=southamerica-east1
 ```
 
 Re-run the same command after editing the JSON — it is declarative and replaces the stored policies, so it is safe to apply repeatedly.

--- a/firebase-public/.gitkeep
+++ b/firebase-public/.gitkeep
@@ -1,0 +1,10 @@
+Intentionally empty.
+
+Firebase Hosting requires a `public` directory, but every path is rewritten to
+the Cloud Run service (see firebase.json). Hosting checks for a static file
+first and falls through to the rewrite when it finds none — so keeping this
+directory empty is what routes all traffic to Django.
+
+Static assets are NOT served from here. They live in the public GCS bucket and
+are fetched directly by the browser, which also keeps them out of Firebase's
+360 MB/day free transfer allowance.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "site": "sitts-504501",
+    "public": "firebase-public",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "run": {
+          "serviceId": "sitts",
+          "region": "southamerica-east1"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The `sitts-project` GCP project was deleted, taking Cloud SQL, Artifact Registry, Secret Manager and the Workload Identity pool with it. This rebuilds everything under `sitts-504501`, sized for a three-user design-partner pilot against a $15/mo budget, and connects the custom domain.

The app is live and serving: **https://sitts-bdhqfqo3cq-rj.a.run.app**

## Infrastructure

Everything in `southamerica-east1`. Cloud SQL `sitts-db` (POSTGRES_16, `db-f1-micro`, zonal, 10GB SSD, 7 daily backups, deletion protection), Cloud Run `sitts` (scale-to-zero), the `sitts-pre-deploy` job, Artifact Registry with its cleanup policy applied from day one, two GCS buckets, `django_settings` in Secret Manager, and repo-scoped Workload Identity Federation.

Deliberately absent, because each is a fixed monthly charge that buys nothing at this traffic: no load balancer (~$18-25/mo), no Serverless VPC connector (~$15-20/mo — Cloud SQL uses a public IP with *zero* authorized networks, reached through Cloud Run's IAM-authenticated connector), no HA (an exact 2x), no App Engine. A $15/mo budget alert is set with thresholds at 50/80/100%.

## Security fix: the media bucket was going to be world-readable

Templates render `{{ obj.file.url }}` directly and `GS_QUERYSTRING_AUTH` was `False`, so URLs were unsigned — and unsigned URLs only resolve if the bucket is public. Since `roles/storage.objectViewer` on `allUsers` also grants `storage.objects.list`, anyone who learned the bucket name could have enumerated and downloaded every contract, bank statement and accountability attachment, on a system that also stores CPF.

Split in two: static assets are public and unsigned (cacheable, nothing sensitive); uploads are private with signed URLs expiring after 15 minutes. Signing uses the IAM `signBlob` API rather than a key file, so `sitts-run` holds `serviceAccountTokenCreator` on itself.

This is not the complete fix. A signed URL is bearer access for its lifetime, and nothing verifies the requester belongs to the tenant owning the file. Serving uploads through a permission-checked view is the real answer; this closes the enumeration hole.

## Custom domain via Firebase Hosting, not a domain mapping

Cloud Run domain mappings are unavailable in `southamerica-east1` — the API returns `501 UNIMPLEMENTED`. Supported regions are `asia-east1, asia-northeast1, asia-southeast1, europe-north1, europe-west1, europe-west4, us-central1, us-east1, us-east4, us-west1`.

Google offers two alternatives. A global external Application Load Balancer is the recommended one and costs more per month than the rest of this infrastructure combined. Firebase Hosting is the other, explicitly supports `southamerica-east1` rewrites, and stays inside its free quota here — static assets load straight from GCS, so only HTML passes through the 360 MB/day allowance.

`firebase-public/` is intentionally empty: Hosting looks for a static file before applying a rewrite, so an empty directory is what routes every path to Django.

**Known limitation:** Firebase Hosting enforces a hard 60s request timeout and returns 504 past it, regardless of Cloud Run's 300s. A large PDF export could exceed that. The `.run.app` URL stays in `CSRF_TRUSTED_ORIGINS` partly as the way around it.

## Two deploy bugs this surfaced

- `gcloud run jobs update` requires the job to already exist, so the workflow could never bootstrap a fresh project. Switched to `deploy`.
- `artifactregistry.writer` cannot *move* a tag, only create one — moving `production` means deleting it first. So the first deploy into a clean project passes and every one after fails, on the final step, after the service has already updated. Fixed with `repoAdmin` scoped to the repository.

## Also

`SECURE_PROXY_SSL_HEADER` was missing. Cloud Run and Firebase both terminate TLS and forward `X-Forwarded-Proto`; without it Django saw every request as plain HTTP — `request.is_secure()` false, `http://` links in password-reset emails, secure cookies never set. Already wrong before Firebase; the proxy hop makes it easier to hit.

Instance sizing from #73 is carried forward unchanged.

## Validation

`manage.py check` clean, `ruff check` and `ruff format --check` clean. Deployed three times end to end; the pipeline is green. Verified live: login 200, health check 200 with `DatabaseBackend` passing in 44ms, `/` redirects to login, static bucket publicly readable, **media bucket returns 401 to anonymous listing**, and Firebase Hosting proxying correctly at `sitts-504501.web.app`.

Not validated: no superuser exists yet, so no authenticated path has been exercised. DNS for `app.sitts.com.br` is still propagating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)