### PR TITLE
fix(accountability): recover Cloud Run document uploads

### DIFF
--- a/accountability/tests.py
+++ b/accountability/tests.py
@@ -1,16 +1,70 @@
 import json
 import shutil
 import tempfile
+from pathlib import Path
+from unittest.mock import patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from easy_tenants import tenant_context
+from google.auth.credentials import Credentials
+from google.cloud.storage.blob import Blob
+from storages.backends.gcloud import GoogleCloudStorage
 
 from accountability.models import Accountability, Expense, ExpenseFile
 from accounts.models import User
+from core import settings as project_settings
+
+
+class TokenOnlyCredentials(Credentials):
+    def refresh(self, request):
+        pass
+
+    @property
+    def service_account_email(self):
+        return "sitts-run@sitts-504501.iam.gserviceaccount.com"
+
+
+class CloudStorageConfigurationTests(SimpleTestCase):
+    def test_private_media_urls_use_iam_sign_blob_with_token_credentials(self):
+        credentials = TokenOnlyCredentials()
+        credentials.token = "access-token"
+        storage_options = dict(
+            getattr(
+                project_settings,
+                "GCS_MEDIA_STORAGE_OPTIONS",
+                {
+                    "default_acl": None,
+                    "querystring_auth": True,
+                },
+            )
+        )
+        storage_options["bucket_name"] = "sitts-private-media"
+        storage = GoogleCloudStorage(
+            credentials=credentials,
+            project_id="sitts-504501",
+            **storage_options,
+        )
+
+        with patch.object(
+            Blob,
+            "generate_signed_url",
+            return_value="https://storage.example/signed-document",
+        ) as generate_signed_url:
+            url = storage.url("uploads/expenses/document.pdf")
+
+        self.assertEqual(url, "https://storage.example/signed-document")
+        self.assertEqual(
+            generate_signed_url.call_args.kwargs.get("service_account_email"),
+            credentials.service_account_email,
+        )
+        self.assertEqual(
+            generate_signed_url.call_args.kwargs.get("access_token"),
+            "access-token",
+        )
 
 
 class ExpenseDocumentWorkspaceTests(TestCase):
@@ -77,6 +131,14 @@ class ExpenseDocumentWorkspaceTests(TestCase):
                 value=value,
                 competency=self.expense.competency,
             )
+
+    def media_files(self):
+        media_root = Path(self.media_root)
+        return {
+            path.relative_to(media_root)
+            for path in media_root.rglob("*")
+            if path.is_file()
+        }
 
     def test_document_list_defaults_to_unassigned_and_paginates(self):
         for index in range(21):
@@ -321,6 +383,11 @@ class ExpenseDocumentWorkspaceTests(TestCase):
         )
         self.assertContains(response, "expenseDisclosureStates")
         self.assertContains(response, "linkedSelectedIds")
+        self.assertContains(response, "parseJsonResponse")
+        self.assertContains(
+            response,
+            "Não foi possível enviar os documentos. Tente novamente.",
+        )
         self.assertContains(response, "Vincular ")
         self.assertNotContains(response, 'class="doc-card__name"')
 
@@ -343,6 +410,58 @@ class ExpenseDocumentWorkspaceTests(TestCase):
             documents = ExpenseFile.objects.filter(accountability=self.accountability)
             self.assertEqual(documents.count(), 2)
             self.assertFalse(documents.filter(expense__isnull=False).exists())
+
+    def test_bulk_upload_rolls_back_rows_and_files_when_signed_url_fails(self):
+        with tenant_context(self.user.organization):
+            document_count = ExpenseFile.objects.filter(
+                accountability=self.accountability
+            ).count()
+        files_before_upload = self.media_files()
+
+        with patch(
+            "django.core.files.storage.FileSystemStorage.url",
+            side_effect=RuntimeError("signed URL failed"),
+        ):
+            response = self.client.post(
+                reverse(
+                    "accountability:expense-document-bulk-upload",
+                    args=[self.accountability.id],
+                ),
+                {
+                    "files": [
+                        SimpleUploadedFile("rollback-1.pdf", b"%PDF-test"),
+                        SimpleUploadedFile("rollback-2.pdf", b"%PDF-test"),
+                    ]
+                },
+            )
+
+        self.assertEqual(response.status_code, 500)
+        with tenant_context(self.user.organization):
+            self.assertEqual(
+                ExpenseFile.objects.filter(accountability=self.accountability).count(),
+                document_count,
+            )
+        self.assertEqual(self.media_files(), files_before_upload)
+
+    def test_bulk_upload_signed_url_failure_returns_json_error(self):
+        with patch(
+            "django.core.files.storage.FileSystemStorage.url",
+            side_effect=RuntimeError("signed URL failed"),
+        ):
+            response = self.client.post(
+                reverse(
+                    "accountability:expense-document-bulk-upload",
+                    args=[self.accountability.id],
+                ),
+                {"files": [SimpleUploadedFile("json-error.pdf", b"%PDF-test")]},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+        self.assertEqual(
+            response.json(),
+            {"error": "Não foi possível enviar os documentos. Tente novamente."},
+        )
 
     def test_assign_endpoint_moves_many_documents_to_one_expense(self):
         with tenant_context(self.user.organization):

--- a/accountability/tests.py
+++ b/accountability/tests.py
@@ -443,6 +443,27 @@ class ExpenseDocumentWorkspaceTests(TestCase):
             )
         self.assertEqual(self.media_files(), files_before_upload)
 
+    def test_bulk_upload_removes_stored_file_when_model_save_fails(self):
+        files_before_upload = self.media_files()
+
+        def fail_after_storage(document, *args, **kwargs):
+            self.assertTrue(document.file.storage.exists(document.file.name))
+            raise RuntimeError("database insert failed")
+
+        with patch.object(ExpenseFile, "save", autospec=True) as model_save:
+            model_save.side_effect = fail_after_storage
+            response = self.client.post(
+                reverse(
+                    "accountability:expense-document-bulk-upload",
+                    args=[self.accountability.id],
+                ),
+                {"files": [SimpleUploadedFile("orphan-on-insert.pdf", b"%PDF-test")]},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+        self.assertEqual(self.media_files(), files_before_upload)
+
     def test_bulk_upload_signed_url_failure_returns_json_error(self):
         with patch(
             "django.core.files.storage.FileSystemStorage.url",

--- a/accountability/views.py
+++ b/accountability/views.py
@@ -1827,6 +1827,20 @@ def _serialize_expense_document(document):
     }
 
 
+def _delete_expense_document_files(documents):
+    for document in documents:
+        try:
+            document.file.delete(save=False)
+        except Exception:
+            logger.exception(
+                "Failed to delete expense document file after upload failure",
+                extra={
+                    "accountability_id": str(document.accountability_id),
+                    "document_id": str(document.id),
+                },
+            )
+
+
 @require_GET
 @login_required
 def expense_document_list_view(request, pk):
@@ -2018,24 +2032,35 @@ def bulk_upload_expense_documents_view(request, pk):
     if errors:
         return JsonResponse({"error": errors[0], "errors": errors}, status=400)
 
-    created = []
-    for uploaded_file in files:
-        document = ExpenseFile.objects.create(
-            accountability=accountability,
-            created_by=request.user,
-            name=uploaded_file.name[:128],
-            file=uploaded_file,
+    created_documents = []
+    created_payload = []
+    try:
+        with db_transaction.atomic():
+            for uploaded_file in files:
+                document = ExpenseFile.objects.create(
+                    accountability=accountability,
+                    created_by=request.user,
+                    name=uploaded_file.name[:128],
+                    file=uploaded_file,
+                )
+                created_documents.append(document)
+                created_payload.append(_serialize_expense_document(document))
+    except Exception:
+        logger.exception(
+            "Bulk expense document upload failed",
+            extra={
+                "accountability_id": str(accountability.id),
+                "file_count": len(files),
+                "user_id": str(request.user.id),
+            },
         )
-        created.append(
-            {
-                "id": str(document.id),
-                "name": document.name,
-                "url": document.file.url,
-                "is_image": document.name.lower().endswith((".jpg", ".jpeg", ".png")),
-            }
+        _delete_expense_document_files(created_documents)
+        return JsonResponse(
+            {"error": "Não foi possível enviar os documentos. Tente novamente."},
+            status=500,
         )
 
-    return JsonResponse({"documents": created}, status=201)
+    return JsonResponse({"documents": created_payload}, status=201)
 
 
 @require_POST

--- a/accountability/views.py
+++ b/accountability/views.py
@@ -2037,13 +2037,16 @@ def bulk_upload_expense_documents_view(request, pk):
     try:
         with db_transaction.atomic():
             for uploaded_file in files:
-                document = ExpenseFile.objects.create(
+                document = ExpenseFile(
                     accountability=accountability,
                     created_by=request.user,
                     name=uploaded_file.name[:128],
-                    file=uploaded_file,
                 )
+                # Object storage is outside the DB transaction. Track the blob
+                # before saving the row so an insert failure cannot orphan it.
+                document.file.save(uploaded_file.name, uploaded_file, save=False)
                 created_documents.append(document)
+                document.save(force_insert=True)
                 created_payload.append(_serialize_expense_document(document))
     except Exception:
         logger.exception(

--- a/core/settings.py
+++ b/core/settings.py
@@ -254,6 +254,14 @@ _legacy_bucket = env("GS_BUCKET_NAME", default="")
 GS_STATIC_BUCKET_NAME = env("GS_STATIC_BUCKET_NAME", default=_legacy_bucket)
 GS_MEDIA_BUCKET_NAME = env("GS_MEDIA_BUCKET_NAME", default=_legacy_bucket)
 
+GCS_MEDIA_STORAGE_OPTIONS = {
+    "bucket_name": GS_MEDIA_BUCKET_NAME,
+    "default_acl": None,
+    "querystring_auth": True,
+    "expiration": timedelta(minutes=15),
+    "iam_sign_blob": True,
+}
+
 STORAGES = {
     # Private bucket. querystring_auth signs every URL, so a link works for the
     # signature's lifetime and cannot be guessed or shared indefinitely.
@@ -265,12 +273,7 @@ STORAGES = {
     # on itself (see docs/DEPLOY.md).
     "default": {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
-        "OPTIONS": {
-            "bucket_name": GS_MEDIA_BUCKET_NAME,
-            "default_acl": None,
-            "querystring_auth": True,
-            "expiration": timedelta(minutes=15),
-        },
+        "OPTIONS": GCS_MEDIA_STORAGE_OPTIONS,
     },
     # Public bucket: CSS/JS/admin assets only. Unsigned so URLs stay stable and
     # cacheable — nothing here is sensitive.

--- a/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
+++ b/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
@@ -119,5 +119,5 @@ Run focused workspace test. Expected: PASS.
 
 - [x] **Step 1: Run focused accountability tests**
 - [x] **Step 2: Run `make check`, `make test-sqlite`, and `make audit-templates`**
-- [ ] **Step 3: Review diff against `main`**
+- [x] **Step 3: Review diff against `main`**
 - [ ] **Step 4: Commit, push branch, and open PR linking issue #80**

--- a/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
+++ b/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
@@ -120,4 +120,4 @@ Run focused workspace test. Expected: PASS.
 - [x] **Step 1: Run focused accountability tests**
 - [x] **Step 2: Run `make check`, `make test-sqlite`, and `make audit-templates`**
 - [x] **Step 3: Review diff against `main`**
-- [ ] **Step 4: Commit, push branch, and open PR linking issue #80**
+- [x] **Step 4: Commit, push branch, and open PR linking issue #80**

--- a/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
+++ b/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
@@ -1,0 +1,123 @@
+# Cloud Run Document Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore private document uploads on Cloud Run without partial batch writes or raw JSON parser errors.
+
+**Architecture:** Enable django-storages IAM signing in shared production media options. Keep request-scoped database writes atomic and explicitly delete created blobs on failure. Guard browser JSON decoding at the upload boundary.
+
+**Tech Stack:** Django 5, django-storages 1.14.6, Google Cloud Storage, server-rendered JavaScript, unittest.
+
+## Global Constraints
+
+- Keep media bucket private and signed URL expiry at 15 minutes.
+- Do not mutate production IAM or clean historical production test data.
+- User-facing copy stays Portuguese, sentence case, and concise.
+- Follow red-green-refactor for behavior changes.
+
+---
+
+### Task 1: IAM media signing
+
+**Files:**
+- Modify: `core/settings.py`
+- Test: `accountability/tests.py`
+
+**Interfaces:**
+- Consumes: django-storages `GoogleCloudStorage(iam_sign_blob=True)`.
+- Produces: `GCS_MEDIA_STORAGE_OPTIONS`, used by production `STORAGES` and tests.
+
+- [ ] **Step 1: Write failing token-only credential test**
+
+Create storage from `GCS_MEDIA_STORAGE_OPTIONS`, call `storage.url()`, and assert
+`Blob.generate_signed_url()` receives `service_account_email` and `access_token`.
+
+- [ ] **Step 2: Verify red**
+
+Run: `make test-sqlite TEST=accountability.tests.CloudStorageConfigurationTests`
+
+Expected: FAIL because production options do not enable IAM signing.
+
+- [ ] **Step 3: Enable IAM signing**
+
+Add `"iam_sign_blob": True` to reusable private-media options and wire those
+options into `STORAGES["default"]`.
+
+- [ ] **Step 4: Verify green**
+
+Run same focused test. Expected: PASS.
+
+### Task 2: Atomic upload cleanup and JSON response
+
+**Files:**
+- Modify: `accountability/views.py`
+- Test: `accountability/tests.py`
+
+**Interfaces:**
+- Consumes: `_serialize_expense_document(document)` and `db_transaction.atomic()`.
+- Produces: `_delete_expense_document_files(documents)` cleanup helper and JSON 500 contract.
+
+- [ ] **Step 1: Write failing rollback test**
+
+Patch storage URL generation to fail after file creation. Post two valid files.
+Assert status 500, JSON generic error, zero new rows, and empty media directory.
+
+- [ ] **Step 2: Verify red**
+
+Run focused rollback test. Expected: FAIL with propagated/HTML 500 and persisted first file.
+
+- [ ] **Step 3: Implement transaction and blob cleanup**
+
+Create and serialize documents inside `db_transaction.atomic()`. On exception,
+delete every recorded file, log original failure, and return:
+
+```python
+JsonResponse(
+    {"error": "Não foi possível enviar os documentos. Tente novamente."},
+    status=500,
+)
+```
+
+- [ ] **Step 4: Verify green**
+
+Run focused upload tests. Expected: PASS.
+
+### Task 3: Browser-safe upload errors
+
+**Files:**
+- Modify: `templates/accountability/expenses/document-workspace.html`
+- Test: `accountability/tests.py`
+
+**Interfaces:**
+- Consumes: Fetch `Response`.
+- Produces: `parseJsonResponse(response, fallbackMessage)`.
+
+- [ ] **Step 1: Add failing rendered-template assertion**
+
+Assert upload workspace includes stable fallback copy and guarded parser call.
+
+- [ ] **Step 2: Verify red**
+
+Run focused workspace render test. Expected: FAIL because guarded parser is absent.
+
+- [ ] **Step 3: Add guarded parser**
+
+Catch JSON decoding errors and throw fallback message. Use it for upload responses.
+
+- [ ] **Step 4: Verify green**
+
+Run focused workspace test. Expected: PASS.
+
+### Task 4: Verification and PR
+
+**Files:**
+- Modify: plan checkboxes as work completes.
+
+**Interfaces:**
+- Consumes: completed tasks.
+- Produces: verified commit and separate pull request against `main`.
+
+- [ ] **Step 1: Run focused accountability tests**
+- [ ] **Step 2: Run `make check`, `make test-sqlite`, and `make audit-templates`**
+- [ ] **Step 3: Review diff against `main`**
+- [ ] **Step 4: Commit, push branch, and open PR linking issue #80**

--- a/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
+++ b/docs/superpowers/plans/2026-08-17-cloud-run-document-upload.md
@@ -27,23 +27,23 @@
 - Consumes: django-storages `GoogleCloudStorage(iam_sign_blob=True)`.
 - Produces: `GCS_MEDIA_STORAGE_OPTIONS`, used by production `STORAGES` and tests.
 
-- [ ] **Step 1: Write failing token-only credential test**
+- [x] **Step 1: Write failing token-only credential test**
 
 Create storage from `GCS_MEDIA_STORAGE_OPTIONS`, call `storage.url()`, and assert
 `Blob.generate_signed_url()` receives `service_account_email` and `access_token`.
 
-- [ ] **Step 2: Verify red**
+- [x] **Step 2: Verify red**
 
 Run: `make test-sqlite TEST=accountability.tests.CloudStorageConfigurationTests`
 
 Expected: FAIL because production options do not enable IAM signing.
 
-- [ ] **Step 3: Enable IAM signing**
+- [x] **Step 3: Enable IAM signing**
 
 Add `"iam_sign_blob": True` to reusable private-media options and wire those
 options into `STORAGES["default"]`.
 
-- [ ] **Step 4: Verify green**
+- [x] **Step 4: Verify green**
 
 Run same focused test. Expected: PASS.
 
@@ -57,16 +57,16 @@ Run same focused test. Expected: PASS.
 - Consumes: `_serialize_expense_document(document)` and `db_transaction.atomic()`.
 - Produces: `_delete_expense_document_files(documents)` cleanup helper and JSON 500 contract.
 
-- [ ] **Step 1: Write failing rollback test**
+- [x] **Step 1: Write failing rollback test**
 
 Patch storage URL generation to fail after file creation. Post two valid files.
 Assert status 500, JSON generic error, zero new rows, and empty media directory.
 
-- [ ] **Step 2: Verify red**
+- [x] **Step 2: Verify red**
 
 Run focused rollback test. Expected: FAIL with propagated/HTML 500 and persisted first file.
 
-- [ ] **Step 3: Implement transaction and blob cleanup**
+- [x] **Step 3: Implement transaction and blob cleanup**
 
 Create and serialize documents inside `db_transaction.atomic()`. On exception,
 delete every recorded file, log original failure, and return:
@@ -78,7 +78,7 @@ JsonResponse(
 )
 ```
 
-- [ ] **Step 4: Verify green**
+- [x] **Step 4: Verify green**
 
 Run focused upload tests. Expected: PASS.
 
@@ -92,19 +92,19 @@ Run focused upload tests. Expected: PASS.
 - Consumes: Fetch `Response`.
 - Produces: `parseJsonResponse(response, fallbackMessage)`.
 
-- [ ] **Step 1: Add failing rendered-template assertion**
+- [x] **Step 1: Add failing rendered-template assertion**
 
 Assert upload workspace includes stable fallback copy and guarded parser call.
 
-- [ ] **Step 2: Verify red**
+- [x] **Step 2: Verify red**
 
 Run focused workspace render test. Expected: FAIL because guarded parser is absent.
 
-- [ ] **Step 3: Add guarded parser**
+- [x] **Step 3: Add guarded parser**
 
 Catch JSON decoding errors and throw fallback message. Use it for upload responses.
 
-- [ ] **Step 4: Verify green**
+- [x] **Step 4: Verify green**
 
 Run focused workspace test. Expected: PASS.
 
@@ -117,7 +117,7 @@ Run focused workspace test. Expected: PASS.
 - Consumes: completed tasks.
 - Produces: verified commit and separate pull request against `main`.
 
-- [ ] **Step 1: Run focused accountability tests**
-- [ ] **Step 2: Run `make check`, `make test-sqlite`, and `make audit-templates`**
+- [x] **Step 1: Run focused accountability tests**
+- [x] **Step 2: Run `make check`, `make test-sqlite`, and `make audit-templates`**
 - [ ] **Step 3: Review diff against `main`**
 - [ ] **Step 4: Commit, push branch, and open PR linking issue #80**

--- a/docs/superpowers/specs/2026-08-17-cloud-run-document-upload-design.md
+++ b/docs/superpowers/specs/2026-08-17-cloud-run-document-upload-design.md
@@ -1,0 +1,39 @@
+# Cloud Run Document Upload Recovery Design
+
+## Context
+
+Production document uploads fail after storing a file because private media URL
+generation tries to sign with Cloud Run's token-only credentials. Issue #80
+contains production evidence and root-cause analysis. Historical production data
+cleanup is explicitly outside this change.
+
+## Design
+
+Private media storage will enable django-storages' IAM `signBlob` mode while
+keeping the bucket private, query-string authentication enabled, and the existing
+15-minute expiry. Runtime service-account permissions remain infrastructure
+prerequisites documented in `docs/DEPLOY.md`; this PR does not mutate production
+IAM.
+
+Bulk upload will become all-or-nothing for rows created by one request. File
+validation remains before writes. Creation and response serialization run inside
+a database transaction so signed-URL failures roll back every new row. Because
+GCS is not transactional, the endpoint records each successfully created model
+and explicitly deletes its blob when any later creation or serialization step
+fails. Cleanup failures are logged without replacing the original response.
+
+The endpoint will return a short JSON 500 error after cleanup. Upload JavaScript
+will also guard JSON decoding so an HTML error from Cloud Run or another proxy
+never exposes `Unexpected token '<'` to users. Existing 4xx messages remain
+unchanged when valid JSON is returned.
+
+## Verification
+
+- Token-only credentials receive `service_account_email` and `access_token`
+  through django-storages' IAM signing path.
+- A signed-URL failure during a multi-file request returns JSON, rolls back all
+  new `ExpenseFile` rows, and removes all blobs created by that request.
+- Successful multi-file upload remains a JSON 201 response.
+- Non-JSON upload responses map to `Não foi possível enviar os documentos. Tente
+  novamente.`
+- Repository checks and full sqlite test suite pass before PR creation.

--- a/templates/accountability/expenses/document-workspace.html
+++ b/templates/accountability/expenses/document-workspace.html
@@ -861,6 +861,14 @@
     }
   }
 
+  async function parseJsonResponse(response, fallbackMessage) {
+    try {
+      return await response.json();
+    } catch (error) {
+      throw new Error(fallbackMessage);
+    }
+  }
+
   async function uploadFiles(files) {
     files = Array.from(files);
     if (!files.length) return;
@@ -884,13 +892,14 @@
       for (let index = 0; index < chunks.length; index++) {
         const data = new FormData();
         chunks[index].forEach(file => data.append('files', file));
+        const uploadErrorMessage = 'Não foi possível enviar os documentos. Tente novamente.';
         const response = await fetch(workspace.dataset.uploadUrl, {
           method: 'POST',
-          headers: { 'X-CSRFToken': csrfToken },
+          headers: { 'X-CSRFToken': csrfToken, 'Accept': 'application/json' },
           body: data
         });
-        const result = await response.json();
-        if (!response.ok) throw new Error(result.error || 'Não foi possível enviar documentos.');
+        const result = await parseJsonResponse(response, uploadErrorMessage);
+        if (!response.ok) throw new Error(result.error || uploadErrorMessage);
         const percent = Math.round(((index + 1) / chunks.length) * 100);
         document.getElementById('upload-percent').textContent = percent + '%';
         document.getElementById('upload-bar').style.width = percent + '%';


### PR DESCRIPTION
## Summary

- enable IAM `signBlob` for private media signed URLs under Cloud Run token-only credentials
- make each upload request atomic and delete stored blobs after model, serialization, or transaction failures
- keep upload failures JSON-safe on server and browser
- add regression coverage for Cloud Run credentials, rollback, blob cleanup, and frontend fallback copy

## Verification

- `make check`
- accountability SQLite tests: 16 passed
- `make audit-templates`
- `make test-sqlite`: 37 passed, 1 pre-existing failure in `AudespFaseIVViewsTests.test_contract_detail_page_renders_fase_iv_tab`; reproduced unchanged on `origin/main`
- standards review: no findings
- spec review: upload cleanup finding resolved

## Production notes

- no historical production data cleanup or production upload test performed, per requester
- runtime service account still requires `roles/iam.serviceAccountTokenCreator` on itself; read-only confirmation could not run because local `gcloud` authentication expired
- no production IAM or data mutation performed

Closes #80